### PR TITLE
Add EventRecorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,40 @@ Check logs:
 $ kubectl -n octops-system logs -f $(kubectl -n octops-system get pod -l app=octops-ingress-controller -o=jsonpath='{.items[*].metadata.name}')
 ```
 
+## Events
+You can track events recorded for each GameServer running `kubectl get events [-w]` and the output will look similar to:
+```
+...
+1s Normal  Creating  gameserver/octops-domain-tqmvm-rcl5p  Creating Service for gameserver default/octops-domain-tqmvm-rcl5p
+0s Normal  Created   gameserver/octops-domain-tqmvm-rcl5p  Service created for gameserver default/octops-domain-tqmvm-rcl5p
+0s Normal  Creating  gameserver/octops-domain-tqmvm-rcl5p  Creating Ingress for gameserver default/octops-domain-tqmvm-rcl5p
+0s Normal  Created   gameserver/octops-domain-tqmvm-rcl5p  Ingress created for gameserver default/octops-domain-tqmvm-rcl5p
+...
+```
+
+The controller will record errors if a resource can be created.
+```
+0s Warning Failed  gameserver/octops-domain-zxt2q-6xl6r  Failed to create Ingress for gameserver default/octops-domain-zxt2q-6xl6r: ingress routing mode domain requires the annotation octops.io/gameserver-ingress-domain to be present on octops-domain-zxt2q-6xl6r, check your Fleet or GameServer manifest.
+```
+
+Alternatively, you can check events for a particular gameserver running
+```
+$ kubectl describe gameserver [gameserver-name]
+...
+Events:
+  Type    Reason          Age    From                           Message
+  ----    ------          ----   ----                           -------
+  Normal  PortAllocation  2m59s  gameserver-controller          Port allocated
+  Normal  Creating        2m59s  gameserver-controller          Pod octops-domain-4sk5v-7gtw4 created
+  Normal  Scheduled       2m59s  gameserver-controller          Address and port populated
+  Normal  RequestReady    2m53s  gameserver-sidecar             SDK state change
+  Normal  Ready           2m53s  gameserver-controller          SDK.Ready() complete
+  Normal  Creating        2m53s  gameserver-ingress-controller  Creating Service for gameserver default/octops-domain-4sk5v-7gtw4
+  Normal  Created         2m53s  gameserver-ingress-controller  Service created for gameserver default/octops-domain-4sk5v-7gtw4
+  Normal  Creating        2m53s  gameserver-ingress-controller  Creating Ingress for gameserver default/octops-domain-4sk5v-7gtw4
+  Normal  Created         2m53s  gameserver-ingress-controller  Ingress created for gameserver default/octops-domain-4sk5v-7gtw4
+```
+
 ## Extras
 
 You can find examples of different issuers on the [deploy/cert-manager](deploy/cert-manager) folder. Make sure you update the information to reflect your environment before applying those manifests.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,7 +71,7 @@ to quickly create a Cobra application.`,
 		})
 
 		logger.Info("starting gameserver controller")
-		ctrl, err := controller.NewGameServerController(mgr, handlers.NewGameSeverEventHandler(clientConf), controller.Options{
+		ctrl, err := controller.NewGameServerController(mgr, handlers.NewGameSeverEventHandler(clientConf, mgr.GetEventRecorderFor("gameserver-ingress-controller")), controller.Options{
 			For: &agonesv1.GameServer{},
 		})
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -100,7 +100,7 @@ func init() {
 
 	rootCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Set KUBECONFIG")
 	rootCmd.Flags().StringVar(&masterURL, "master", "", "The addr of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
-	rootCmd.Flags().StringVar(&syncPeriod, "sync-period", "5s", "Set the minimum frequency at which watched resources are reconciled")
+	rootCmd.Flags().StringVar(&syncPeriod, "sync-period", "15s", "Set the minimum frequency at which watched resources are reconciled")
 	rootCmd.Flags().IntVar(&port, "port", 30234, "Port used by the manager for webhooks")
 }
 

--- a/pkg/handlers/gameserver_handler.go
+++ b/pkg/handlers/gameserver_handler.go
@@ -30,7 +30,7 @@ func NewGameSeverEventHandler(config *rest.Config, recorder record.EventRecorder
 	return &GameSeverEventHandler{
 		logger:            runtime.Logger().WithField("role", "event_handler"),
 		client:            client,
-		serviceReconciler: reconcilers.NewServiceReconciler(client),
+		serviceReconciler: reconcilers.NewServiceReconciler(client, recorder),
 		ingressReconciler: reconcilers.NewIngressReconciler(client, recorder),
 	}
 }

--- a/pkg/handlers/gameserver_handler.go
+++ b/pkg/handlers/gameserver_handler.go
@@ -46,7 +46,7 @@ func (h *GameSeverEventHandler) OnAdd(obj interface{}) error {
 	return nil
 }
 
-func (h *GameSeverEventHandler) OnUpdate(oldObj interface{}, newObj interface{}) error {
+func (h *GameSeverEventHandler) OnUpdate(_ interface{}, newObj interface{}) error {
 	h.logger.WithField("event", "updated").Infof("%s", newObj.(*agonesv1.GameServer).Name)
 
 	gs := gameserver.FromObject(newObj)

--- a/pkg/handlers/gameserver_handler.go
+++ b/pkg/handlers/gameserver_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 )
 
 type GameSeverEventHandler struct {
@@ -20,7 +21,7 @@ type GameSeverEventHandler struct {
 	ingressReconciler *reconcilers.IngressReconciler
 }
 
-func NewGameSeverEventHandler(config *rest.Config) *GameSeverEventHandler {
+func NewGameSeverEventHandler(config *rest.Config, recorder record.EventRecorder) *GameSeverEventHandler {
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		runtime.Logger().WithError(err).Fatal("failed to create kubernetes client")
@@ -30,7 +31,7 @@ func NewGameSeverEventHandler(config *rest.Config) *GameSeverEventHandler {
 		logger:            runtime.Logger().WithField("role", "event_handler"),
 		client:            client,
 		serviceReconciler: reconcilers.NewServiceReconciler(client),
-		ingressReconciler: reconcilers.NewIngressReconciler(client),
+		ingressReconciler: reconcilers.NewIngressReconciler(client, recorder),
 	}
 }
 

--- a/pkg/reconcilers/common.go
+++ b/pkg/reconcilers/common.go
@@ -1,0 +1,9 @@
+package reconcilers
+
+const (
+	EventTypeNormal         string = "Normal"
+	EventTypeWarning               = "Warning"
+	ReasonReconcileFailed          = "Failed"
+	ReasonReconciled               = "Created"
+	ReasonReconcileCreating        = "Creating"
+)

--- a/pkg/reconcilers/ingress_reconciler.go
+++ b/pkg/reconcilers/ingress_reconciler.go
@@ -47,7 +47,7 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, gs *agonesv1.GameServ
 }
 
 func (r *IngressReconciler) reconcileNotFound(ctx context.Context, gs *agonesv1.GameServer) (*networkingv1.Ingress, error) {
-	r.recorder.RecordCreating(gs)
+	r.recorder.RecordCreating(gs, IngressKind)
 
 	mode := gameserver.GetIngressRoutingMode(gs)
 	issuer := gameserver.GetTLSCertIssuer(gs)
@@ -60,17 +60,17 @@ func (r *IngressReconciler) reconcileNotFound(ctx context.Context, gs *agonesv1.
 
 	ingress, err := newIngress(gs, opts...)
 	if err != nil {
-		r.recorder.RecordFailed(gs, err)
+		r.recorder.RecordFailed(gs, IngressKind, err)
 		return nil, errors.Wrapf(err, "failed to create ingress for gameserver %s", gs.Name)
 	}
 
 	result, err := r.Client.NetworkingV1().Ingresses(gs.Namespace).Create(ctx, ingress, metav1.CreateOptions{})
 	if err != nil {
-		r.recorder.RecordFailed(gs, err)
+		r.recorder.RecordFailed(gs, IngressKind, err)
 		return nil, errors.Wrapf(err, "failed to push ingress %s for gameserver %s", ingress.Name, gs.Name)
 	}
 
-	r.recorder.RecordSuccess(gs)
+	r.recorder.RecordSuccess(gs, IngressKind)
 	return result, nil
 }
 

--- a/pkg/reconcilers/ingress_reconciler.go
+++ b/pkg/reconcilers/ingress_reconciler.go
@@ -3,7 +3,6 @@ package reconcilers
 import (
 	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
 	"context"
-	"fmt"
 	. "github.com/Octops/gameserver-ingress-controller/internal/runtime"
 	"github.com/Octops/gameserver-ingress-controller/pkg/gameserver"
 	"github.com/pkg/errors"
@@ -11,7 +10,6 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 )
@@ -22,14 +20,14 @@ var (
 
 type IngressReconciler struct {
 	logger   *logrus.Entry
-	recorder record.EventRecorder
+	recorder *EventRecorder
 	Client   *kubernetes.Clientset
 }
 
 func NewIngressReconciler(client *kubernetes.Clientset, recorder record.EventRecorder) *IngressReconciler {
 	return &IngressReconciler{
 		logger:   Logger().WithField("role", "ingress_reconciler"),
-		recorder: recorder,
+		recorder: NewEventRecorder(recorder),
 		Client:   client,
 	}
 }
@@ -49,7 +47,7 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, gs *agonesv1.GameServ
 }
 
 func (r *IngressReconciler) reconcileNotFound(ctx context.Context, gs *agonesv1.GameServer) (*networkingv1.Ingress, error) {
-	r.RecordCreating(gs)
+	r.recorder.RecordCreating(gs)
 
 	mode := gameserver.GetIngressRoutingMode(gs)
 	issuer := gameserver.GetTLSCertIssuer(gs)
@@ -62,34 +60,18 @@ func (r *IngressReconciler) reconcileNotFound(ctx context.Context, gs *agonesv1.
 
 	ingress, err := newIngress(gs, opts...)
 	if err != nil {
-		r.RecordFailed(gs, err)
+		r.recorder.RecordFailed(gs, err)
 		return nil, errors.Wrapf(err, "failed to create ingress for gameserver %s", gs.Name)
 	}
 
 	result, err := r.Client.NetworkingV1().Ingresses(gs.Namespace).Create(ctx, ingress, metav1.CreateOptions{})
 	if err != nil {
-		r.RecordFailed(gs, err)
+		r.recorder.RecordFailed(gs, err)
 		return nil, errors.Wrapf(err, "failed to push ingress %s for gameserver %s", ingress.Name, gs.Name)
 	}
 
-	r.RecordSuccess(gs)
+	r.recorder.RecordSuccess(gs)
 	return result, nil
-}
-
-func (r *IngressReconciler) RecordFailed(gs *agonesv1.GameServer, err error) {
-	r.recordEvent(gs, EventTypeWarning, ReasonReconcileFailed, fmt.Sprintf("Failed to create ingress for gameserver %s/%s: %s", gs.Namespace, gs.Name, err))
-}
-
-func (r *IngressReconciler) RecordSuccess(gs *agonesv1.GameServer) {
-	r.recordEvent(gs, EventTypeNormal, ReasonReconciled, fmt.Sprintf("Ingress created for gameserver %s/%s", gs.Namespace, gs.Name))
-}
-
-func (r *IngressReconciler) RecordCreating(gs *agonesv1.GameServer) {
-	r.recordEvent(gs, EventTypeNormal, ReasonReconcileCreating, fmt.Sprintf("Creating Ingress for gameserver %s/%s", gs.Namespace, gs.Name))
-}
-
-func (r *IngressReconciler) recordEvent(object runtime.Object, eventtype, reason, message string) {
-	r.recorder.Event(object, eventtype, reason, message)
 }
 
 func newIngress(gs *agonesv1.GameServer, options ...IngressOption) (*networkingv1.Ingress, error) {

--- a/pkg/reconcilers/recorder.go
+++ b/pkg/reconcilers/recorder.go
@@ -1,0 +1,32 @@
+package reconcilers
+
+import (
+	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
+	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+)
+
+type EventRecorder struct {
+	recorder record.EventRecorder
+}
+
+func NewEventRecorder(recorder record.EventRecorder) *EventRecorder {
+	return &EventRecorder{recorder: recorder}
+}
+
+func (r *EventRecorder) RecordFailed(gs *agonesv1.GameServer, err error) {
+	r.recordEvent(gs, EventTypeWarning, ReasonReconcileFailed, fmt.Sprintf("Failed to create ingress for gameserver %s/%s: %s", gs.Namespace, gs.Name, err))
+}
+
+func (r *EventRecorder) RecordSuccess(gs *agonesv1.GameServer) {
+	r.recordEvent(gs, EventTypeNormal, ReasonReconciled, fmt.Sprintf("Ingress created for gameserver %s/%s", gs.Namespace, gs.Name))
+}
+
+func (r *EventRecorder) RecordCreating(gs *agonesv1.GameServer) {
+	r.recordEvent(gs, EventTypeNormal, ReasonReconcileCreating, fmt.Sprintf("Creating Ingress for gameserver %s/%s", gs.Namespace, gs.Name))
+}
+
+func (r *EventRecorder) recordEvent(object runtime.Object, eventtype, reason, message string) {
+	r.recorder.Event(object, eventtype, reason, message)
+}

--- a/pkg/reconcilers/recorder.go
+++ b/pkg/reconcilers/recorder.go
@@ -7,6 +7,11 @@ import (
 	"k8s.io/client-go/tools/record"
 )
 
+const (
+	IngressKind = "Ingress"
+	ServiceKind = "Service"
+)
+
 type EventRecorder struct {
 	recorder record.EventRecorder
 }
@@ -15,16 +20,16 @@ func NewEventRecorder(recorder record.EventRecorder) *EventRecorder {
 	return &EventRecorder{recorder: recorder}
 }
 
-func (r *EventRecorder) RecordFailed(gs *agonesv1.GameServer, err error) {
-	r.recordEvent(gs, EventTypeWarning, ReasonReconcileFailed, fmt.Sprintf("Failed to create ingress for gameserver %s/%s: %s", gs.Namespace, gs.Name, err))
+func (r *EventRecorder) RecordFailed(gs *agonesv1.GameServer, kind string, err error) {
+	r.recordEvent(gs, EventTypeWarning, ReasonReconcileFailed, fmt.Sprintf("Failed to create %s for gameserver %s/%s: %s", kind, gs.Namespace, gs.Name, err))
 }
 
-func (r *EventRecorder) RecordSuccess(gs *agonesv1.GameServer) {
-	r.recordEvent(gs, EventTypeNormal, ReasonReconciled, fmt.Sprintf("Ingress created for gameserver %s/%s", gs.Namespace, gs.Name))
+func (r *EventRecorder) RecordSuccess(gs *agonesv1.GameServer, kind string) {
+	r.recordEvent(gs, EventTypeNormal, ReasonReconciled, fmt.Sprintf("%s created for gameserver %s/%s", kind, gs.Namespace, gs.Name))
 }
 
-func (r *EventRecorder) RecordCreating(gs *agonesv1.GameServer) {
-	r.recordEvent(gs, EventTypeNormal, ReasonReconcileCreating, fmt.Sprintf("Creating Ingress for gameserver %s/%s", gs.Namespace, gs.Name))
+func (r *EventRecorder) RecordCreating(gs *agonesv1.GameServer, kind string) {
+	r.recordEvent(gs, EventTypeNormal, ReasonReconcileCreating, fmt.Sprintf("Creating %s for gameserver %s/%s", kind, gs.Namespace, gs.Name))
 }
 
 func (r *EventRecorder) recordEvent(object runtime.Object, eventtype, reason, message string) {

--- a/pkg/reconcilers/service_reconciler.go
+++ b/pkg/reconcilers/service_reconciler.go
@@ -44,7 +44,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, gs *agonesv1.GameServ
 }
 
 func (r *ServiceReconciler) reconcileNotFound(ctx context.Context, gs *agonesv1.GameServer) (*corev1.Service, error) {
-	r.recorder.RecordCreating(gs)
+	r.recorder.RecordCreating(gs, ServiceKind)
 
 	ref := metav1.NewControllerRef(gs, agonesv1.SchemeGroupVersion.WithKind("GameServer"))
 	service := &corev1.Service{
@@ -76,10 +76,10 @@ func (r *ServiceReconciler) reconcileNotFound(ctx context.Context, gs *agonesv1.
 	result, err := r.Client.CoreV1().Services(gs.Namespace).Create(ctx, service, metav1.CreateOptions{})
 	if err != nil {
 		r.logger.WithError(err).Errorf("failed to create service %s", service.Name)
-		r.recorder.RecordFailed(gs, err)
+		r.recorder.RecordFailed(gs, ServiceKind, err)
 		return nil, errors.Wrap(err, "failed to create service")
 	}
 
-	r.recorder.RecordSuccess(gs)
+	r.recorder.RecordSuccess(gs, ServiceKind)
 	return result, nil
 }

--- a/pkg/reconcilers/service_reconciler.go
+++ b/pkg/reconcilers/service_reconciler.go
@@ -12,17 +12,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
 )
 
 type ServiceReconciler struct {
-	logger *logrus.Entry
-	Client *kubernetes.Clientset
+	logger   *logrus.Entry
+	recorder *EventRecorder
+	Client   *kubernetes.Clientset
 }
 
-func NewServiceReconciler(client *kubernetes.Clientset) *ServiceReconciler {
+func NewServiceReconciler(client *kubernetes.Clientset, recorder record.EventRecorder) *ServiceReconciler {
 	return &ServiceReconciler{
-		logger: runtime.Logger().WithField("role", "service_reconciler"),
-		Client: client,
+		logger:   runtime.Logger().WithField("role", "service_reconciler"),
+		recorder: NewEventRecorder(recorder),
+		Client:   client,
 	}
 }
 
@@ -41,8 +44,9 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, gs *agonesv1.GameServ
 }
 
 func (r *ServiceReconciler) reconcileNotFound(ctx context.Context, gs *agonesv1.GameServer) (*corev1.Service, error) {
-	ref := metav1.NewControllerRef(gs, agonesv1.SchemeGroupVersion.WithKind("GameServer"))
+	r.recorder.RecordCreating(gs)
 
+	ref := metav1.NewControllerRef(gs, agonesv1.SchemeGroupVersion.WithKind("GameServer"))
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gs.Name,
@@ -72,8 +76,10 @@ func (r *ServiceReconciler) reconcileNotFound(ctx context.Context, gs *agonesv1.
 	result, err := r.Client.CoreV1().Services(gs.Namespace).Create(ctx, service, metav1.CreateOptions{})
 	if err != nil {
 		r.logger.WithError(err).Errorf("failed to create service %s", service.Name)
+		r.recorder.RecordFailed(gs, err)
 		return nil, errors.Wrap(err, "failed to create service")
 	}
 
+	r.recorder.RecordSuccess(gs)
 	return result, nil
 }


### PR DESCRIPTION
This PR delivers the EventRecorder that allows events to be added to the Gameserver while reconciling.

It will record the 3 major steps: Creating, Created or Failed