### PR TITLE
Support custom gameserver annotations to be passed to the ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,45 @@ The table below shows how the information from the gameserver is used to compose
 | name                                | [hostname, path] | 
 | annotation: octops.io/gameserver-ingress-mode | [domain, path] |
 | annotation: octops.io/gameserver-ingress-domain | base domain |
-|octops.io/gameserver-ingress-fqdn | global domain| 
+|annotation: octops.io/gameserver-ingress-fqdn | global domain| 
 |annotation: octops.io/terminate-tls | terminate TLS |
 |annotation: octops.io/issuer-tls-name| name of the issuer |
+|annotation: octops-[custom-annotation] | custom-annotation |
+
+### Custom Annotations
+Any Fleet or GameServer annotation that contains the prefix `octops-` will be added down to the Ingress resourced crated by the controller.
+
+`octops-nginx.ingress.kubernetes.io/proxy-read-timeout ` :`10`
+
+Will be added to the ingress in the following format:
+
+`nginx.ingress.kubernetes.io/proxy-read-timeout `:`10`
+
+**Any annotation can be used and it is not restricted to NGINX controller annotations**
+
+`octops-my-custom-annotations`: `my-custom-value` will be passed to the Ingress resource as:
+
+`my-custom-annotations`: `my-custom-value`
+
+Multiline is also supported
+
+```yaml
+annotations:
+    octops-nginx.ingress.kubernetes.io/server-snippet: |
+          set $agentflag 0;
+
+          if ($http_user_agent ~* "(Mobile)" ){
+            set $agentflag 1;
+          }
+
+          if ( $agentflag = 1 ) {
+            return 301 https://m.example.com;
+          }
+```
+
+**Remember that the max length of a label name is 63 characters. That limit is imposed by Kubernetes**
+
+https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 
 ## Clean up and Gameserver Lifecycle
 Every resource created by the gameserver ingress controller is attached to the gameserver itself. That means, when a gameserver is deleted from the cluster all its dependencies will be cleaned up by the Kubernetes garbage collector.

--- a/pkg/gameserver/gameserver.go
+++ b/pkg/gameserver/gameserver.go
@@ -15,7 +15,7 @@ const (
 	OctopsAnnotationIngressFQDN   = "octops.io/gameserver-ingress-fqdn"
 	OctopsAnnotationTerminateTLS  = "octops.io/terminate-tls"
 	OctopsAnnotationIssuerName    = "octops.io/issuer-tls-name"
-	OctopsAnnotationCustomIngress = "octops.io/ingress-annotation-"
+	OctopsAnnotationCustomPrefix  = "octops-"
 
 	CertManagerAnnotationIssuer = "cert-manager.io/issuer"
 	AgonesGameServerNameLabel   = "agones.dev/gameserver"

--- a/pkg/gameserver/gameserver.go
+++ b/pkg/gameserver/gameserver.go
@@ -15,6 +15,7 @@ const (
 	OctopsAnnotationIngressFQDN   = "octops.io/gameserver-ingress-fqdn"
 	OctopsAnnotationTerminateTLS  = "octops.io/terminate-tls"
 	OctopsAnnotationIssuerName    = "octops.io/issuer-tls-name"
+	OctopsAnnotationCustomIngress = "octops.io/ingress-annotation-"
 
 	CertManagerAnnotationIssuer = "cert-manager.io/issuer"
 	AgonesGameServerNameLabel   = "agones.dev/gameserver"

--- a/pkg/handlers/gameserver_handler.go
+++ b/pkg/handlers/gameserver_handler.go
@@ -65,10 +65,6 @@ func (h *GameSeverEventHandler) OnDelete(obj interface{}) error {
 	return nil
 }
 
-func (h GameSeverEventHandler) Client() *kubernetes.Clientset {
-	return h.client
-}
-
 func (h *GameSeverEventHandler) Reconcile(gs *agonesv1.GameServer) error {
 	if _, ok := gameserver.HasAnnotation(gs, gameserver.OctopsAnnotationIngressMode); !ok {
 		h.logger.Debugf("skipping gameserver %s/%s, annotation %s not present", gs.Namespace, gs.Name, gameserver.OctopsAnnotationIngressMode)
@@ -85,12 +81,12 @@ func (h *GameSeverEventHandler) Reconcile(gs *agonesv1.GameServer) error {
 	ctx := context.TODO()
 	_, err := h.serviceReconciler.Reconcile(ctx, gs)
 	if err != nil {
-		return errors.Wrap(err, "failed to reconcile gameserver/service")
+		return errors.Wrapf(err, "failed to reconcile service %s/%s", gs.Namespace, gs.Name)
 	}
 
 	_, err = h.ingressReconciler.Reconcile(ctx, gs)
 	if err != nil {
-		return errors.Wrap(err, "failed to reconcile ingress")
+		return errors.Wrapf(err, "failed to reconcile ingress %s/%s", gs.Namespace, gs.Name)
 	}
 
 	return nil

--- a/pkg/reconcilers/common.go
+++ b/pkg/reconcilers/common.go
@@ -1,9 +1,15 @@
 package reconcilers
 
+import networkingv1 "k8s.io/api/networking/v1"
+
 const (
 	EventTypeNormal         string = "Normal"
 	EventTypeWarning               = "Warning"
 	ReasonReconcileFailed          = "Failed"
 	ReasonReconciled               = "Created"
 	ReasonReconcileCreating        = "Creating"
+)
+
+var (
+	defaultPathType = networkingv1.PathTypePrefix
 )

--- a/pkg/reconcilers/ingress_reconciler.go
+++ b/pkg/reconcilers/ingress_reconciler.go
@@ -78,6 +78,7 @@ func newIngress(gs *agonesv1.GameServer, options ...IngressOption) (*networkingv
 			Labels: map[string]string{
 				gameserver.AgonesGameServerNameLabel: gs.Name,
 			},
+			Annotations:     map[string]string{},
 			OwnerReferences: []metav1.OwnerReference{*ref},
 		},
 	}

--- a/pkg/reconcilers/ingress_reconciler.go
+++ b/pkg/reconcilers/ingress_reconciler.go
@@ -45,6 +45,7 @@ func (r *IngressReconciler) reconcileNotFound(ctx context.Context, gs *agonesv1.
 	issuer := gameserver.GetTLSCertIssuer(gs)
 
 	opts := []IngressOption{
+		WithCustomAnnotations(),
 		WithIngressRule(mode),
 		WithTLS(mode),
 		WithTLSCertIssuer(issuer),

--- a/pkg/reconcilers/ingress_reconciler.go
+++ b/pkg/reconcilers/ingress_reconciler.go
@@ -3,10 +3,8 @@ package reconcilers
 import (
 	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
 	"context"
-	. "github.com/Octops/gameserver-ingress-controller/internal/runtime"
 	"github.com/Octops/gameserver-ingress-controller/pkg/gameserver"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	networkingv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,19 +12,13 @@ import (
 	"k8s.io/client-go/tools/record"
 )
 
-var (
-	defaultPathType = networkingv1.PathTypePrefix
-)
-
 type IngressReconciler struct {
-	logger   *logrus.Entry
 	recorder *EventRecorder
 	Client   *kubernetes.Clientset
 }
 
 func NewIngressReconciler(client *kubernetes.Clientset, recorder record.EventRecorder) *IngressReconciler {
 	return &IngressReconciler{
-		logger:   Logger().WithField("role", "ingress_reconciler"),
 		recorder: NewEventRecorder(recorder),
 		Client:   client,
 	}

--- a/pkg/reconcilers/ingress_reconciler_test.go
+++ b/pkg/reconcilers/ingress_reconciler_test.go
@@ -34,11 +34,11 @@ func Test_NewIngress_DomainRoutingMode(t *testing.T) {
 			customAnnotationValue := "my_custom_annotation_value"
 
 			gs := newGameServer(map[string]string{
-				gameserver.OctopsAnnotationIngressMode:                      string(gameserver.IngressRoutingModeDomain),
-				gameserver.OctopsAnnotationIngressDomain:                    domain,
-				gameserver.OctopsAnnotationTerminateTLS:                     strconv.FormatBool(tc.terminateTLS),
-				gameserver.OctopsAnnotationIssuerName:                       tc.certTLSIssuer,
-				gameserver.OctopsAnnotationCustomIngress + customAnnotation: customAnnotationValue,
+				gameserver.OctopsAnnotationIngressMode:                     string(gameserver.IngressRoutingModeDomain),
+				gameserver.OctopsAnnotationIngressDomain:                   domain,
+				gameserver.OctopsAnnotationTerminateTLS:                    strconv.FormatBool(tc.terminateTLS),
+				gameserver.OctopsAnnotationIssuerName:                      tc.certTLSIssuer,
+				gameserver.OctopsAnnotationCustomPrefix + customAnnotation: customAnnotationValue,
 			})
 
 			mode := gameserver.GetIngressRoutingMode(gs)
@@ -103,11 +103,11 @@ func Test_NewIngress_PathRoutingMode(t *testing.T) {
 			customAnnotationValue := "my_custom_annotation_value"
 
 			gs := newGameServer(map[string]string{
-				gameserver.OctopsAnnotationIngressFQDN:                      fqdn,
-				gameserver.OctopsAnnotationIngressMode:                      string(gameserver.IngressRoutingModePath),
-				gameserver.OctopsAnnotationTerminateTLS:                     strconv.FormatBool(tc.terminateTLS),
-				gameserver.OctopsAnnotationIssuerName:                       tc.certTLSIssuer,
-				gameserver.OctopsAnnotationCustomIngress + customAnnotation: customAnnotationValue,
+				gameserver.OctopsAnnotationIngressFQDN:                     fqdn,
+				gameserver.OctopsAnnotationIngressMode:                     string(gameserver.IngressRoutingModePath),
+				gameserver.OctopsAnnotationTerminateTLS:                    strconv.FormatBool(tc.terminateTLS),
+				gameserver.OctopsAnnotationIssuerName:                      tc.certTLSIssuer,
+				gameserver.OctopsAnnotationCustomPrefix + customAnnotation: customAnnotationValue,
 			})
 
 			mode := gameserver.GetIngressRoutingMode(gs)

--- a/pkg/reconcilers/ingress_reconciler_test.go
+++ b/pkg/reconcilers/ingress_reconciler_test.go
@@ -30,11 +30,15 @@ func Test_NewIngress_DomainRoutingMode(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			domain := "foo.bar"
+			customAnnotation := "my_custom_annotation"
+			customAnnotationValue := "my_custom_annotation_value"
+
 			gs := newGameServer(map[string]string{
-				gameserver.OctopsAnnotationIngressMode:   string(gameserver.IngressRoutingModeDomain),
-				gameserver.OctopsAnnotationIngressDomain: domain,
-				gameserver.OctopsAnnotationTerminateTLS:  strconv.FormatBool(tc.terminateTLS),
-				gameserver.OctopsAnnotationIssuerName:    tc.certTLSIssuer,
+				gameserver.OctopsAnnotationIngressMode:                      string(gameserver.IngressRoutingModeDomain),
+				gameserver.OctopsAnnotationIngressDomain:                    domain,
+				gameserver.OctopsAnnotationTerminateTLS:                     strconv.FormatBool(tc.terminateTLS),
+				gameserver.OctopsAnnotationIssuerName:                       tc.certTLSIssuer,
+				gameserver.OctopsAnnotationCustomIngress + customAnnotation: customAnnotationValue,
 			})
 
 			mode := gameserver.GetIngressRoutingMode(gs)
@@ -45,6 +49,7 @@ func Test_NewIngress_DomainRoutingMode(t *testing.T) {
 			rules := newIngressRule(host, "/", gs.Name, gameserver.GetGameServerPort(gs).Port)
 
 			opts := []IngressOption{
+				WithCustomAnnotations(),
 				WithIngressRule(mode),
 				WithTLS(mode),
 				WithTLSCertIssuer(issuerName),
@@ -56,6 +61,8 @@ func Test_NewIngress_DomainRoutingMode(t *testing.T) {
 			require.Equal(t, gameserver.GetGameServerPort(gs).Port, ig.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Backend.Service.Port.Number)
 			require.Contains(t, ig.Labels, gameserver.AgonesGameServerNameLabel)
 			require.Equal(t, ig.Labels[gameserver.AgonesGameServerNameLabel], gs.Name)
+			require.Contains(t, ig.Annotations, customAnnotation)
+			require.Equal(t, ig.Annotations[customAnnotation], customAnnotationValue)
 			require.Equal(t, []metav1.OwnerReference{*ref}, ig.OwnerReferences)
 			require.Equal(t, tls, ig.Spec.TLS)
 			require.Equal(t, rules, ig.Spec.Rules)
@@ -92,11 +99,15 @@ func Test_NewIngress_PathRoutingMode(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fqdn := "servers.foo.bar"
+			customAnnotation := "my_custom_annotation"
+			customAnnotationValue := "my_custom_annotation_value"
+
 			gs := newGameServer(map[string]string{
-				gameserver.OctopsAnnotationIngressFQDN:  fqdn,
-				gameserver.OctopsAnnotationIngressMode:  string(gameserver.IngressRoutingModePath),
-				gameserver.OctopsAnnotationTerminateTLS: strconv.FormatBool(tc.terminateTLS),
-				gameserver.OctopsAnnotationIssuerName:   tc.certTLSIssuer,
+				gameserver.OctopsAnnotationIngressFQDN:                      fqdn,
+				gameserver.OctopsAnnotationIngressMode:                      string(gameserver.IngressRoutingModePath),
+				gameserver.OctopsAnnotationTerminateTLS:                     strconv.FormatBool(tc.terminateTLS),
+				gameserver.OctopsAnnotationIssuerName:                       tc.certTLSIssuer,
+				gameserver.OctopsAnnotationCustomIngress + customAnnotation: customAnnotationValue,
 			})
 
 			mode := gameserver.GetIngressRoutingMode(gs)
@@ -107,6 +118,7 @@ func Test_NewIngress_PathRoutingMode(t *testing.T) {
 			rules := newIngressRule(gs.Annotations[gameserver.OctopsAnnotationIngressFQDN], "/"+gs.Name, gs.Name, gameserver.GetGameServerPort(gs).Port)
 
 			opts := []IngressOption{
+				WithCustomAnnotations(),
 				WithIngressRule(mode),
 				WithTLS(mode),
 				WithTLSCertIssuer(issuerName),
@@ -119,6 +131,8 @@ func Test_NewIngress_PathRoutingMode(t *testing.T) {
 			require.Equal(t, "/"+gs.Name, ig.Spec.Rules[0].IngressRuleValue.HTTP.Paths[0].Path)
 			require.Contains(t, ig.Labels, gameserver.AgonesGameServerNameLabel)
 			require.Equal(t, ig.Labels[gameserver.AgonesGameServerNameLabel], gs.Name)
+			require.Contains(t, ig.Annotations, customAnnotation)
+			require.Equal(t, ig.Annotations[customAnnotation], customAnnotationValue)
 			require.Equal(t, []metav1.OwnerReference{*ref}, ig.OwnerReferences)
 			require.Equal(t, tls, ig.Spec.TLS)
 			require.Equal(t, rules, ig.Spec.Rules)

--- a/pkg/reconcilers/options.go
+++ b/pkg/reconcilers/options.go
@@ -18,6 +18,9 @@ func WithCustomAnnotations() IngressOption {
 		for k, v := range gs.Annotations {
 			if strings.HasPrefix(k, gameserver.OctopsAnnotationCustomPrefix) {
 				custom := strings.TrimPrefix(k, gameserver.OctopsAnnotationCustomPrefix)
+				if len(custom) == 0 {
+					return errors.New("custom annotation does not contain a suffix")
+				}
 				annotations[custom] = v
 			}
 		}

--- a/pkg/reconcilers/options.go
+++ b/pkg/reconcilers/options.go
@@ -12,6 +12,21 @@ import (
 
 type IngressOption func(gs *agonesv1.GameServer, ingress *networkingv1.Ingress) error
 
+func WithCustomAnnotations() IngressOption {
+	return func(gs *agonesv1.GameServer, ingress *networkingv1.Ingress) error {
+		annotations := ingress.Annotations
+		for k, v := range gs.Annotations {
+			if strings.HasPrefix(k, gameserver.OctopsAnnotationCustomIngress) {
+				custom := strings.Replace(k, gameserver.OctopsAnnotationCustomIngress, "", -1)
+				annotations[custom] = v
+			}
+		}
+
+		ingress.SetAnnotations(annotations)
+		return nil
+	}
+}
+
 func WithTLS(mode gameserver.IngressRoutingMode) IngressOption {
 	return func(gs *agonesv1.GameServer, ingress *networkingv1.Ingress) error {
 		errMsgInvalidAnnotation := func(mode, annotation string) error {

--- a/pkg/reconcilers/options.go
+++ b/pkg/reconcilers/options.go
@@ -112,10 +112,7 @@ func WithTLSCertIssuer(issuerName string) IngressOption {
 			return errors.Errorf("annotation %s for %s must be present, check your Fleet or GameServer manifest.", gameserver.OctopsAnnotationIssuerName, gs.Name)
 		}
 
-		ingress.Annotations = map[string]string{
-			gameserver.CertManagerAnnotationIssuer: issuerName,
-		}
-
+		ingress.Annotations[gameserver.CertManagerAnnotationIssuer] = issuerName
 		return nil
 	}
 }

--- a/pkg/reconcilers/options.go
+++ b/pkg/reconcilers/options.go
@@ -16,8 +16,8 @@ func WithCustomAnnotations() IngressOption {
 	return func(gs *agonesv1.GameServer, ingress *networkingv1.Ingress) error {
 		annotations := ingress.Annotations
 		for k, v := range gs.Annotations {
-			if strings.HasPrefix(k, gameserver.OctopsAnnotationCustomIngress) {
-				custom := strings.Replace(k, gameserver.OctopsAnnotationCustomIngress, "", -1)
+			if strings.HasPrefix(k, gameserver.OctopsAnnotationCustomPrefix) {
+				custom := strings.TrimPrefix(k, gameserver.OctopsAnnotationCustomPrefix)
 				annotations[custom] = v
 			}
 		}

--- a/pkg/reconcilers/options_test.go
+++ b/pkg/reconcilers/options_test.go
@@ -1,0 +1,73 @@
+package reconcilers
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_WithCustomAnnotations(t *testing.T) {
+	testCases := []struct {
+		name        string
+		annotations map[string]string
+		expected    map[string]string
+		notExpected map[string]string
+		wantErr     bool
+		err         error
+	}{
+		{
+			name: "with single custom annotation",
+			annotations: map[string]string{
+				"octops.io/ingress-annotation-my-annotation": "my_custom_annotation_value",
+			},
+			expected: map[string]string{
+				"my-annotation": "my_custom_annotation_value",
+			},
+			wantErr: false,
+		},
+		{
+			name: "with two custom annotations",
+			annotations: map[string]string{
+				"octops.io/ingress-annotation-my-annotation-one": "my_custom_annotation_value_one",
+				"octops.io/ingress-annotation-my-annotation-two": "my_custom_annotation_value_two",
+			},
+			expected: map[string]string{
+				"my-annotation-one": "my_custom_annotation_value_one",
+				"my-annotation-two": "my_custom_annotation_value_two",
+			},
+			wantErr: false,
+		},
+		{
+			name: "return only one custom annotation",
+			annotations: map[string]string{
+				"octops.io/ingress-annotation-my-annotation-one": "my_custom_annotation_value_one",
+				"octops.io/another-annotation":                   "another_annotation_value",
+			},
+			expected: map[string]string{
+				"my-annotation-one": "my_custom_annotation_value_one",
+			},
+			notExpected: map[string]string{
+				"octops.io/another-annotation": "another_annotation_value",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gs := newGameServer(tc.annotations)
+
+			ingress, err := newIngress(gs, WithCustomAnnotations())
+			require.NoError(t, err)
+
+			for k, v := range tc.expected {
+				value, ok := ingress.Annotations[k]
+				require.True(t, ok, "annotations %s is not present", k)
+				require.Equal(t, v, value)
+			}
+
+			for k, _ := range tc.notExpected {
+				require.NotContains(t, ingress.Annotations, k, "annotations %s should not present", k)
+			}
+		})
+	}
+}

--- a/pkg/reconcilers/options_test.go
+++ b/pkg/reconcilers/options_test.go
@@ -17,6 +17,7 @@ func Test_WithCustomAnnotations(t *testing.T) {
 		annotations map[string]string
 		expected    map[string]string
 		notExpected map[string]string
+		wantErr     bool
 	}{
 		{
 			name: "with single custom annotation",
@@ -87,6 +88,14 @@ func Test_WithCustomAnnotations(t *testing.T) {
         }`,
 			},
 		},
+		{
+			name: "error with annotations prefix only",
+			annotations: map[string]string{
+				newCustomAnnotation(""): "anyValue",
+			},
+			expected: map[string]string{},
+			wantErr:  true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -94,7 +103,12 @@ func Test_WithCustomAnnotations(t *testing.T) {
 			gs := newGameServer(tc.annotations)
 
 			ingress, err := newIngress(gs, WithCustomAnnotations())
-			require.NoError(t, err)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Equal(t, "custom annotation does not contain a suffix", err.Error())
+			} else {
+				require.NoError(t, err)
+			}
 
 			for k, v := range tc.expected {
 				value, ok := ingress.Annotations[k]

--- a/pkg/reconcilers/options_test.go
+++ b/pkg/reconcilers/options_test.go
@@ -1,11 +1,17 @@
 package reconcilers
 
 import (
+	"fmt"
+	"github.com/Octops/gameserver-ingress-controller/pkg/gameserver"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 func Test_WithCustomAnnotations(t *testing.T) {
+	newCustomAnnotation := func(custom string) string {
+		return fmt.Sprintf("%s%s", gameserver.OctopsAnnotationCustomPrefix, custom)
+	}
+
 	testCases := []struct {
 		name        string
 		annotations map[string]string
@@ -17,7 +23,7 @@ func Test_WithCustomAnnotations(t *testing.T) {
 		{
 			name: "with single custom annotation",
 			annotations: map[string]string{
-				"octops.io/ingress-annotation-my-annotation": "my_custom_annotation_value",
+				newCustomAnnotation("my-annotation"): "my_custom_annotation_value",
 			},
 			expected: map[string]string{
 				"my-annotation": "my_custom_annotation_value",
@@ -27,8 +33,8 @@ func Test_WithCustomAnnotations(t *testing.T) {
 		{
 			name: "with two custom annotations",
 			annotations: map[string]string{
-				"octops.io/ingress-annotation-my-annotation-one": "my_custom_annotation_value_one",
-				"octops.io/ingress-annotation-my-annotation-two": "my_custom_annotation_value_two",
+				newCustomAnnotation("my-annotation-one"): "my_custom_annotation_value_one",
+				newCustomAnnotation("my-annotation-two"): "my_custom_annotation_value_two",
 			},
 			expected: map[string]string{
 				"my-annotation-one": "my_custom_annotation_value_one",
@@ -39,14 +45,24 @@ func Test_WithCustomAnnotations(t *testing.T) {
 		{
 			name: "return only one custom annotation",
 			annotations: map[string]string{
-				"octops.io/ingress-annotation-my-annotation-one": "my_custom_annotation_value_one",
-				"octops.io/another-annotation":                   "another_annotation_value",
+				newCustomAnnotation("my-annotation-one"): "my_custom_annotation_value_one",
+				"octops.io/another-annotation":           "another_annotation_value",
 			},
 			expected: map[string]string{
 				"my-annotation-one": "my_custom_annotation_value_one",
 			},
 			notExpected: map[string]string{
 				"octops.io/another-annotation": "another_annotation_value",
+			},
+			wantErr: false,
+		},
+		{
+			name: "with complex annotations",
+			annotations: map[string]string{
+				newCustomAnnotation("nginx.ingress.kubernetes.io/proxy-read-timeout"): "10",
+			},
+			expected: map[string]string{
+				"nginx.ingress.kubernetes.io/proxy-read-timeout": "10",
 			},
 			wantErr: false,
 		},

--- a/pkg/reconcilers/options_test.go
+++ b/pkg/reconcilers/options_test.go
@@ -17,8 +17,6 @@ func Test_WithCustomAnnotations(t *testing.T) {
 		annotations map[string]string
 		expected    map[string]string
 		notExpected map[string]string
-		wantErr     bool
-		err         error
 	}{
 		{
 			name: "with single custom annotation",
@@ -28,7 +26,6 @@ func Test_WithCustomAnnotations(t *testing.T) {
 			expected: map[string]string{
 				"my-annotation": "my_custom_annotation_value",
 			},
-			wantErr: false,
 		},
 		{
 			name: "with two custom annotations",
@@ -40,7 +37,6 @@ func Test_WithCustomAnnotations(t *testing.T) {
 				"my-annotation-one": "my_custom_annotation_value_one",
 				"my-annotation-two": "my_custom_annotation_value_two",
 			},
-			wantErr: false,
 		},
 		{
 			name: "return only one custom annotation",
@@ -54,7 +50,6 @@ func Test_WithCustomAnnotations(t *testing.T) {
 			notExpected: map[string]string{
 				"octops.io/another-annotation": "another_annotation_value",
 			},
-			wantErr: false,
 		},
 		{
 			name: "with complex annotations",
@@ -64,7 +59,33 @@ func Test_WithCustomAnnotations(t *testing.T) {
 			expected: map[string]string{
 				"nginx.ingress.kubernetes.io/proxy-read-timeout": "10",
 			},
-			wantErr: false,
+		},
+		{
+			name: "with multiline annotation",
+			annotations: map[string]string{
+				newCustomAnnotation("nginx.ingress.kubernetes.io/server-snippet"): `|
+        set $agentflag 0;
+
+        if ($http_user_agent ~* "(Mobile)" ){
+          set $agentflag 1;
+        }
+
+        if ( $agentflag = 1 ) {
+          return 301 https://m.example.com;
+        }`,
+			},
+			expected: map[string]string{
+				"nginx.ingress.kubernetes.io/server-snippet": `|
+        set $agentflag 0;
+
+        if ($http_user_agent ~* "(Mobile)" ){
+          set $agentflag 1;
+        }
+
+        if ( $agentflag = 1 ) {
+          return 301 https://m.example.com;
+        }`,
+			},
 		},
 	}
 

--- a/pkg/reconcilers/service_reconciler.go
+++ b/pkg/reconcilers/service_reconciler.go
@@ -3,10 +3,8 @@ package reconcilers
 import (
 	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
 	"context"
-	"github.com/Octops/gameserver-ingress-controller/internal/runtime"
 	"github.com/Octops/gameserver-ingress-controller/pkg/gameserver"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,14 +14,12 @@ import (
 )
 
 type ServiceReconciler struct {
-	logger   *logrus.Entry
 	recorder *EventRecorder
 	Client   *kubernetes.Clientset
 }
 
 func NewServiceReconciler(client *kubernetes.Clientset, recorder record.EventRecorder) *ServiceReconciler {
 	return &ServiceReconciler{
-		logger:   runtime.Logger().WithField("role", "service_reconciler"),
 		recorder: NewEventRecorder(recorder),
 		Client:   client,
 	}
@@ -75,7 +71,6 @@ func (r *ServiceReconciler) reconcileNotFound(ctx context.Context, gs *agonesv1.
 
 	result, err := r.Client.CoreV1().Services(gs.Namespace).Create(ctx, service, metav1.CreateOptions{})
 	if err != nil {
-		r.logger.WithError(err).Errorf("failed to create service %s", service.Name)
 		r.recorder.RecordFailed(gs, ServiceKind, err)
 		return nil, errors.Wrap(err, "failed to create service")
 	}


### PR DESCRIPTION
Reference https://github.com/Octops/gameserver-ingress-controller/issues/7

Fleets or Gameservers can set annotations using the prefix `octops-`. Any annotation following this convention will be added to the Ingress resource created by the GameServer Ingress Controller.

For example:

`octops-nginx.ingress.kubernetes.io/proxy-read-timeout ` :`10`

Will be added to the ingress in the following format:

`nginx.ingress.kubernetes.io/proxy-read-timeout `:`10`

**Any annotation can be used and it is not restricted to NGINX controller annotations**

`octops-my-custom-annotations`: `my-custom-value` will be passed to the Ingress resource as:

`my-custom-annotations`: `my-custom-value` 

Multiline is also supported

```yaml
annotations:
    octops-nginx.ingress.kubernetes.io/server-snippet: |
          set $agentflag 0;

          if ($http_user_agent ~* "(Mobile)" ){
            set $agentflag 1;
          }

          if ( $agentflag = 1 ) {
            return 301 https://m.example.com;
          }
```

**Remember that the max length of a label name is 63 characters. That limit is imposed by Kubernetes**
https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/