### PR TITLE
Support Health checks endpoints for Liveness and Readiness

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,12 +27,14 @@ import (
 )
 
 var (
-	cfgFile    string
-	masterURL  string
-	kubeconfig string
-	syncPeriod string
-	port       int
-	verbose    bool
+	cfgFile                string
+	masterURL              string
+	kubeconfig             string
+	syncPeriod             string
+	webhookPort            int
+	healthProbeBindAddress string
+	metricsBindAddress     string
+	verbose                bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -52,10 +54,12 @@ to quickly create a Cobra application.`,
 		runtime.SetupSignal(cancel)
 
 		app.StartController(ctx, app.Config{
-			Kubeconfig: kubeconfig,
-			SyncPeriod: syncPeriod,
-			Port:       port,
-			Verbose:    verbose,
+			Kubeconfig:             kubeconfig,
+			SyncPeriod:             syncPeriod,
+			Port:                   webhookPort,
+			HealthProbeBindAddress: healthProbeBindAddress,
+			MetricsBindAddress:     metricsBindAddress,
+			Verbose:                verbose,
 		})
 	},
 }
@@ -77,7 +81,9 @@ func init() {
 	rootCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Set KUBECONFIG")
 	rootCmd.Flags().StringVar(&masterURL, "master", "", "The addr of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	rootCmd.Flags().StringVar(&syncPeriod, "sync-period", "15s", "Set the minimum frequency at which watched resources are reconciled")
-	rootCmd.Flags().IntVar(&port, "port", 30234, "Port used by the manager for webhooks")
+	rootCmd.Flags().StringVar(&healthProbeBindAddress, "health-probe-addrs", ":30235", "TCP address that the controller should bind to for serving health probes")
+	rootCmd.Flags().StringVar(&metricsBindAddress, "metrics-addrs", ":9090", "TCP address that the controller should bind to for serving prometheus metrics")
+	rootCmd.Flags().IntVar(&webhookPort, "webhook-port", 30234, "Port used by the controller for webhooks")
 	rootCmd.Flags().BoolVar(&verbose, "verbose", false, "Produce verbose log")
 }
 

--- a/deploy/install.yaml
+++ b/deploy/install.yaml
@@ -69,8 +69,13 @@ spec:
     spec:
       serviceAccountName: octops
       containers:
-        - image: octops/gameserver-ingress-controller:0.1.3
+        - image: octops/gameserver-ingress-controller:latest # Tag latest is not ideal, check the latest released tag and replace
           name: controller
+          ports:
+            - containerPort: 30235
+              name: healthz
+            - containerPort: 9090
+              name: metrics
           args:
             - --sync-period=15s
           imagePullPolicy: Always
@@ -81,3 +86,11 @@ spec:
             limits:
               cpu: "1"
               memory: "150Mi"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 30235
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 30235

--- a/pkg/app/controller.go
+++ b/pkg/app/controller.go
@@ -3,19 +3,24 @@ package app
 import (
 	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
 	"context"
+	"fmt"
 	"github.com/Octops/gameserver-ingress-controller/internal/runtime"
 	"github.com/Octops/gameserver-ingress-controller/pkg/controller"
 	"github.com/Octops/gameserver-ingress-controller/pkg/handlers"
 	"github.com/Octops/gameserver-ingress-controller/pkg/k8sutil"
 	"github.com/Octops/gameserver-ingress-controller/pkg/manager"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"time"
 )
 
 type Config struct {
-	Kubeconfig string
-	SyncPeriod string
-	Port       int
-	Verbose    bool
+	Kubeconfig             string
+	SyncPeriod             string
+	Port                   int
+	Verbose                bool
+	HealthProbeBindAddress string
+	MetricsBindAddress     string
 }
 
 func StartController(ctx context.Context, config Config) error {
@@ -23,27 +28,39 @@ func StartController(ctx context.Context, config Config) error {
 
 	clientConf, err := k8sutil.NewClusterConfig(config.Kubeconfig)
 	if err != nil {
-		logger.Fatal(err)
+		withFatal(logger, err, "failed to create cluster config")
 	}
 
 	duration, err := time.ParseDuration(config.SyncPeriod)
 	if err != nil {
-		logger.WithError(err).Fatalf("error parsing sync-period flag: %s", config.SyncPeriod)
+		withFatal(logger, err, fmt.Sprintf("error parsing sync-period flag: %s", config.SyncPeriod))
 	}
 
 	mgr, err := manager.NewManager(clientConf, manager.Options{
-		SyncPeriod: &duration,
-		Port:       config.Port,
+		SyncPeriod:             &duration,
+		Port:                   config.Port,
+		HealthProbeBindAddress: config.HealthProbeBindAddress,
+		MetricsBindAddress:     config.MetricsBindAddress,
 	})
+	if err != nil {
+		withFatal(logger, err, "failed to create controller manager")
+	}
 
 	logger.Info("starting gameserver controller")
 	ctrl, err := controller.NewGameServerController(mgr, handlers.NewGameSeverEventHandler(clientConf, mgr.GetEventRecorderFor("gameserver-ingress-controller")), controller.Options{
 		For: &agonesv1.GameServer{},
 	})
+	if err != nil {
+		withFatal(logger, err, "failed to create controller")
+	}
 
 	if err := ctrl.Start(ctx); err != nil {
-		logger.Fatal(err)
+		withFatal(logger, err, "failed to start controller")
 	}
 
 	return nil
+}
+
+func withFatal(logger *logrus.Entry, err error, msg string) {
+	logger.Fatal(errors.Wrap(err, msg))
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -3,13 +3,16 @@ package manager
 import (
 	"github.com/pkg/errors"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"time"
 )
 
 type Options struct {
-	SyncPeriod *time.Duration
-	Port int
+	SyncPeriod             *time.Duration
+	Port                   int
+	HealthProbeBindAddress string
+	MetricsBindAddress     string
 }
 
 type Manager struct {
@@ -18,13 +21,26 @@ type Manager struct {
 
 func NewManager(config *rest.Config, options Options) (*Manager, error) {
 	mgr, err := manager.New(config, manager.Options{
-		SyncPeriod: options.SyncPeriod,
-		Port: options.Port,
+		SyncPeriod:             options.SyncPeriod,
+		Port:                   options.Port,
+		MetricsBindAddress:     options.MetricsBindAddress,
+		HealthProbeBindAddress: options.HealthProbeBindAddress,
 	})
-
 	if err != nil {
-		return nil, errors.Wrap(err, "manager could not be created")
+		return nil, withError(err)
+	}
+
+	if err := mgr.AddHealthzCheck("/", healthz.Ping); err != nil {
+		return nil, withError(err)
+	}
+
+	if err := mgr.AddReadyzCheck("/", healthz.Ping); err != nil {
+		return nil, withError(err)
 	}
 
 	return &Manager{mgr}, nil
+}
+
+func withError(err error) error {
+	return errors.Wrap(err, "failed to create manager")
 }


### PR DESCRIPTION
The suggestion was proposed on https://github.com/Octops/gameserver-ingress-controller/issues/15#issuecomment-979433562

While adding the Health checks endpoints I decided to include the metrics endpoint. Currently those metrics are only related to the controller itself. There is another [issue #16](https://github.com/Octops/gameserver-ingress-controller/issues/16) that will cover specific metrics for the reconcile process.