### PR TITLE
Make HAProxy the official ingress controller

### DIFF
--- a/deploy/cert-manager/production-issuer.yaml
+++ b/deploy/cert-manager/production-issuer.yaml
@@ -17,4 +17,4 @@ spec:
     solvers:
       - http01:
           ingress:
-            class: nginx
+            class: haproxy

--- a/deploy/cert-manager/staging-issuer.yaml
+++ b/deploy/cert-manager/staging-issuer.yaml
@@ -17,4 +17,4 @@ spec:
     solvers:
       - http01:
           ingress:
-            class:  nginx
+            class:  haproxy

--- a/examples/fleet-dev.yaml
+++ b/examples/fleet-dev.yaml
@@ -27,21 +27,24 @@ spec:
         cluster: gke-1.22
         region: us-east-1
       annotations:
-        octops.io/gameserver-ingress-mode: "domain"
-        octops.io/gameserver-ingress-domain: "example.com"
-        octops.io/terminate-tls: "true"
-        octops.io/issuer-tls-name: "selfsigned-issuer"
+#        octops.io/gameserver-ingress-mode: "domain"
+#        octops.io/gameserver-ingress-domain: "example.com"
+        octops.io/gameserver-ingress-mode: "path"
+        octops.io/gameserver-ingress-fqdn: "servers.example.com"
+        octops-kubernetes.io/ingress.class: haproxy
     spec:
+      health:
+        disabled: true
       ports:
         - name: default
-          containerPort: 8088
+          containerPort: 8010
           protocol: TCP
       template:
         spec:
           containers:
             - name: gameserver
               imagePullPolicy: Always
-              image: octops/gameserver-http:latest
+              image: ksdn117/web-socket-test
               resources:
                 requests:
                   memory: "64Mi"

--- a/examples/fleet-dev.yaml
+++ b/examples/fleet-dev.yaml
@@ -31,7 +31,7 @@ spec:
 #        octops.io/gameserver-ingress-domain: "example.com"
         octops.io/gameserver-ingress-mode: "path"
         octops.io/gameserver-ingress-fqdn: "servers.example.com"
-        octops-kubernetes.io/ingress.class: haproxy
+        octops-kubernetes.io/ingress.class: "haproxy"
     spec:
       health:
         disabled: true

--- a/examples/fleet-domain.yaml
+++ b/examples/fleet-domain.yaml
@@ -27,6 +27,7 @@ spec:
         cluster: gke-1.17
         region: us-east-1
       annotations:
+        octops-kubernetes.io/ingress.class: "haproxy"
         octops.io/gameserver-ingress-mode: "domain"
         octops.io/gameserver-ingress-domain: "example.com"
         #octops.io/tls-secret-name: "custom-secret"

--- a/examples/fleet-path.yaml
+++ b/examples/fleet-path.yaml
@@ -27,6 +27,7 @@ spec:
         cluster: gke-1.17
         region: us-east-1
       annotations:
+        octops-kubernetes.io/ingress.class: "haproxy"
         octops.io/gameserver-ingress-mode: "path"
         octops.io/gameserver-ingress-fqdn: "servers.example.com"
         #octops.io/tls-secret-name: "custom-secret"

--- a/examples/quake/quake-fleet.yaml
+++ b/examples/quake/quake-fleet.yaml
@@ -56,6 +56,7 @@ spec:
         cluster: gke-1.17
         region: us-east-1
       annotations:
+        octops-kubernetes.io/ingress.class: "haproxy"
         octops.io/gameserver-ingress-mode: "domain"
         octops.io/gameserver-ingress-domain: "arena.com"
         octops.io/terminate-tls: "true"

--- a/pkg/gameserver/gameserver.go
+++ b/pkg/gameserver/gameserver.go
@@ -18,7 +18,7 @@ const (
 	OctopsAnnotationIssuerName     = "octops.io/issuer-tls-name"
 	OctopsAnnotationCustomPrefix   = "octops-"
 
-	CertManagerAnnotationIssuer = "cert-manager.io/issuer"
+	CertManagerAnnotationIssuer = "cert-manager.io/cluster-issuer"
 	AgonesGameServerNameLabel   = "agones.dev/gameserver"
 
 	ErrGameServerAnnotationEmpty = "gameserver %s/%s has annotation %s but it is empty"

--- a/pkg/reconcilers/options_test.go
+++ b/pkg/reconcilers/options_test.go
@@ -56,37 +56,25 @@ func Test_WithCustomAnnotations(t *testing.T) {
 		{
 			name: "with complex annotations",
 			annotations: map[string]string{
-				newCustomAnnotation("nginx.ingress.kubernetes.io/proxy-read-timeout"): "10",
+				newCustomAnnotation("haproxy.org/rate-limit-status-code"): "429",
 			},
 			expected: map[string]string{
-				"nginx.ingress.kubernetes.io/proxy-read-timeout": "10",
+				"haproxy.org/rate-limit-status-code": "429",
 			},
 		},
 		{
 			name: "with multiline annotation",
 			annotations: map[string]string{
-				newCustomAnnotation("nginx.ingress.kubernetes.io/server-snippet"): `|
-        set $agentflag 0;
-
-        if ($http_user_agent ~* "(Mobile)" ){
-          set $agentflag 1;
-        }
-
-        if ( $agentflag = 1 ) {
-          return 301 https://m.example.com;
-        }`,
+				newCustomAnnotation("haproxy.org/backend-config-snippet"): `|
+        http-send-name-header x-dst-server
+        stick-table type string len 32 size 100k expire 30m
+        stick on req.cook(sessionid)`,
 			},
 			expected: map[string]string{
-				"nginx.ingress.kubernetes.io/server-snippet": `|
-        set $agentflag 0;
-
-        if ($http_user_agent ~* "(Mobile)" ){
-          set $agentflag 1;
-        }
-
-        if ( $agentflag = 1 ) {
-          return 301 https://m.example.com;
-        }`,
+				"haproxy.org/backend-config-snippet": `|
+        http-send-name-header x-dst-server
+        stick-table type string len 32 size 100k expire 30m
+        stick on req.cook(sessionid)`,
 			},
 		},
 		{


### PR DESCRIPTION
As reported on https://github.com/Octops/gameserver-ingress-controller/issues/21 the NGINX Ingress Controller imposes limitations for games using websocket.

This PR updates the project in order to make HAProxy https://github.com/haproxytech/kubernetes-ingress the official ingress controller.