### PR TITLE
Bump release tag to 0.1.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ OCTOPS_BIN := bin/octops-controller
 
 IMAGE_REPO=octops/gameserver-ingress-controller
 DOCKER_IMAGE_TAG ?= octops/gameserver-ingress-controller:${VERSION}
-RELEASE_TAG=0.1.5
+RELEASE_TAG=0.1.6
 
 default: clean build
 


### PR DESCRIPTION
Bump the release tag to 0.1.6

This release makes HAProxy the recommended Ingress Controller.

Details on https://github.com/Octops/gameserver-ingress-controller/issues/21