### PR TITLE
Extract Store from Reconcilers

### DIFF
--- a/pkg/app/controller.go
+++ b/pkg/app/controller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Octops/gameserver-ingress-controller/pkg/handlers"
 	"github.com/Octops/gameserver-ingress-controller/pkg/k8sutil"
 	"github.com/Octops/gameserver-ingress-controller/pkg/manager"
+	"github.com/Octops/gameserver-ingress-controller/pkg/record"
 	"github.com/Octops/gameserver-ingress-controller/pkg/stores"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -54,7 +55,9 @@ func StartController(ctx context.Context, config Config) error {
 	}
 
 	logger.WithField("component", "controller").Info("starting gameserver controller")
-	handler := handlers.NewGameSeverEventHandler(store, mgr.GetEventRecorderFor("gameserver-ingress-controller"))
+
+	recorder := mgr.GetEventRecorderFor("gameserver-ingress-controller")
+	handler := handlers.NewGameSeverEventHandler(store, record.NewEventRecorder(recorder))
 	ctrl, err := controller.NewGameServerController(mgr, handler, controller.Options{
 		For: &agonesv1.GameServer{},
 	})

--- a/pkg/controller/gameserver_controller.go
+++ b/pkg/controller/gameserver_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"github.com/Octops/gameserver-ingress-controller/internal/runtime"
 	"github.com/Octops/gameserver-ingress-controller/pkg/handlers"
 	"github.com/Octops/gameserver-ingress-controller/pkg/reconcilers"
 	"github.com/sirupsen/logrus"
@@ -32,9 +33,9 @@ type GameServerController struct {
 
 func NewGameServerController(mgr manager.Manager, eventHandler handlers.EventHandler, options Options) (*GameServerController, error) {
 	optFor := reflect.TypeOf(options.For).Elem().String()
-	logger := logrus.WithFields(logrus.Fields{
-		"source":          "controller",
-		"controller_type": optFor,
+	logger := runtime.Logger().WithFields(logrus.Fields{
+		"component": "controller",
+		"resource":  optFor,
 	})
 
 	err := ctrl.NewControllerManagedBy(mgr).
@@ -126,7 +127,6 @@ func NewGameServerController(mgr manager.Manager, eventHandler handlers.EventHan
 		Manager: mgr,
 	}
 
-	logger.Infof("controller created for resource of type %s", optFor)
 	return controller, nil
 }
 
@@ -137,6 +137,7 @@ func (c *GameServerController) Start(ctx context.Context) error {
 		c.Manager.Start(chDone)
 	}()
 
+	c.logger.Info("gameserver controller started")
 	<-ctx.Done()
 
 	return nil

--- a/pkg/handlers/gameserver_handler.go
+++ b/pkg/handlers/gameserver_handler.go
@@ -7,11 +7,11 @@ import (
 	"github.com/Octops/gameserver-ingress-controller/internal/runtime"
 	"github.com/Octops/gameserver-ingress-controller/pkg/gameserver"
 	"github.com/Octops/gameserver-ingress-controller/pkg/reconcilers"
+	"github.com/Octops/gameserver-ingress-controller/pkg/record"
 	"github.com/Octops/gameserver-ingress-controller/pkg/stores"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/record"
 )
 
 type GameSeverEventHandler struct {
@@ -21,7 +21,7 @@ type GameSeverEventHandler struct {
 	ingressReconciler *reconcilers.IngressReconciler
 }
 
-func NewGameSeverEventHandler(store *stores.Store, recorder record.EventRecorder) *GameSeverEventHandler {
+func NewGameSeverEventHandler(store *stores.Store, recorder *record.EventRecorder) *GameSeverEventHandler {
 	return &GameSeverEventHandler{
 		logger:            runtime.Logger().WithField("component", "event_handler"),
 		serviceReconciler: reconcilers.NewServiceReconciler(store, recorder),

--- a/pkg/handlers/gameserver_handler.go
+++ b/pkg/handlers/gameserver_handler.go
@@ -7,12 +7,10 @@ import (
 	"github.com/Octops/gameserver-ingress-controller/internal/runtime"
 	"github.com/Octops/gameserver-ingress-controller/pkg/gameserver"
 	"github.com/Octops/gameserver-ingress-controller/pkg/reconcilers"
+	"github.com/Octops/gameserver-ingress-controller/pkg/stores"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	v1 "k8s.io/client-go/informers/core/v1"
-	networkingv1 "k8s.io/client-go/informers/networking/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -23,17 +21,11 @@ type GameSeverEventHandler struct {
 	ingressReconciler *reconcilers.IngressReconciler
 }
 
-func NewGameSeverEventHandler(config *rest.Config, svcInformer v1.ServiceInformer, ingressInformer networkingv1.IngressInformer, recorder record.EventRecorder) *GameSeverEventHandler {
-	client, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		runtime.Logger().WithError(err).Fatal("failed to create kubernetes client")
-	}
-
+func NewGameSeverEventHandler(store *stores.Store, recorder record.EventRecorder) *GameSeverEventHandler {
 	return &GameSeverEventHandler{
-		logger:            runtime.Logger().WithField("role", "event_handler"),
-		client:            client,
-		serviceReconciler: reconcilers.NewServiceReconciler(client, svcInformer, recorder),
-		ingressReconciler: reconcilers.NewIngressReconciler(client, ingressInformer, recorder),
+		logger:            runtime.Logger().WithField("component", "event_handler"),
+		serviceReconciler: reconcilers.NewServiceReconciler(store, recorder),
+		ingressReconciler: reconcilers.NewIngressReconciler(store, recorder),
 	}
 }
 

--- a/pkg/k8sutil/k8sutil.go
+++ b/pkg/k8sutil/k8sutil.go
@@ -1,6 +1,10 @@
 package k8sutil
 
 import (
+	"fmt"
+	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"os"
@@ -8,6 +12,20 @@ import (
 
 // KubeConfigEnv (optionally) specify the location of kubeconfig file
 const KubeConfigEnv = "KUBECONFIG"
+
+func NewClientSet(kubeconfig string) (kubernetes.Interface, error) {
+	clientConf, err := NewClusterConfig(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := kubernetes.NewForConfig(clientConf)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create kubernetes client")
+	}
+
+	return client, nil
+}
 
 func NewClusterConfig(kubeconfig string) (*rest.Config, error) {
 	var cfg *rest.Config
@@ -23,8 +41,12 @@ func NewClusterConfig(kubeconfig string) (*rest.Config, error) {
 	}
 
 	// Increase QPS and Burst - https://github.com/prometheus-operator/prometheus-operator/blob/main/pkg/k8sutil/k8sutil.go#L96-L97
-	cfg.QPS = 100
-	cfg.Burst = 100
+	cfg.QPS = 1000
+	cfg.Burst = 1000
 
 	return cfg, nil
+}
+
+func Namespaced(obj v1.Object) string {
+	return fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName())
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -1,8 +1,8 @@
 package manager
 
 import (
+	"github.com/Octops/gameserver-ingress-controller/pkg/k8sutil"
 	"github.com/pkg/errors"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"time"
@@ -19,7 +19,12 @@ type Manager struct {
 	manager.Manager
 }
 
-func NewManager(config *rest.Config, options Options) (*Manager, error) {
+func NewManager(kubeconfig string, options Options) (*Manager, error) {
+	config, err := k8sutil.NewClusterConfig(kubeconfig)
+	if err != nil {
+		return nil, withError(errors.Wrap(err, "failed to create cluster config"))
+	}
+
 	mgr, err := manager.New(config, manager.Options{
 		SyncPeriod:             options.SyncPeriod,
 		Port:                   options.Port,

--- a/pkg/reconcilers/common.go
+++ b/pkg/reconcilers/common.go
@@ -2,14 +2,6 @@ package reconcilers
 
 import networkingv1 "k8s.io/api/networking/v1"
 
-const (
-	EventTypeNormal         string = "Normal"
-	EventTypeWarning               = "Warning"
-	ReasonReconcileFailed          = "Failed"
-	ReasonReconciled               = "Created"
-	ReasonReconcileCreating        = "Creating"
-)
-
 var (
 	defaultPathType = networkingv1.PathTypePrefix
 )

--- a/pkg/reconcilers/ingress_reconciler.go
+++ b/pkg/reconcilers/ingress_reconciler.go
@@ -9,33 +9,34 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/client-go/informers/networking/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 )
 
+type IngressStore interface {
+	CreateIngress(ctx context.Context, ingress *networkingv1.Ingress, options metav1.CreateOptions) (*networkingv1.Ingress, error)
+	GetIngress(name, namespace string) (*networkingv1.Ingress, error)
+}
+
 type IngressReconciler struct {
-	Client   *kubernetes.Clientset
-	informer v1.IngressInformer
+	store    IngressStore
 	recorder *EventRecorder
 }
 
-func NewIngressReconciler(client *kubernetes.Clientset, informer v1.IngressInformer, recorder record.EventRecorder) *IngressReconciler {
+func NewIngressReconciler(store IngressStore, recorder record.EventRecorder) *IngressReconciler {
 	return &IngressReconciler{
-		Client:   client,
-		informer: informer,
+		store:    store,
 		recorder: NewEventRecorder(recorder),
 	}
 }
 
 func (r *IngressReconciler) Reconcile(ctx context.Context, gs *agonesv1.GameServer) (*networkingv1.Ingress, error) {
-	ingress, err := r.informer.Lister().Ingresses(gs.Namespace).Get(gs.Name)
+	ingress, err := r.store.GetIngress(gs.Name, gs.Namespace)
 	if err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return &networkingv1.Ingress{}, errors.Wrapf(err, "error retrieving Ingress %s from namespace %s", gs.Name, gs.Namespace)
+		if k8serrors.IsNotFound(err) {
+			return r.reconcileNotFound(ctx, gs)
 		}
 
-		return r.reconcileNotFound(ctx, gs)
+		return nil, errors.Wrapf(err, "error retrieving Ingress %s from namespace %s", gs.Name, gs.Namespace)
 	}
 
 	//TODO: Validate if details still match the GS info
@@ -61,7 +62,7 @@ func (r *IngressReconciler) reconcileNotFound(ctx context.Context, gs *agonesv1.
 		return nil, errors.Wrapf(err, "failed to create ingress for gameserver %s", gs.Name)
 	}
 
-	result, err := r.Client.NetworkingV1().Ingresses(gs.Namespace).Create(ctx, ingress, metav1.CreateOptions{})
+	result, err := r.store.CreateIngress(ctx, ingress, metav1.CreateOptions{})
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			r.recorder.RecordFailed(gs, IngressKind, err)
@@ -82,7 +83,8 @@ func newIngress(gs *agonesv1.GameServer, options ...IngressOption) (*networkingv
 	ref := metav1.NewControllerRef(gs, agonesv1.SchemeGroupVersion.WithKind("GameServer"))
 	ig := &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: gs.Name,
+			Name:      gs.Name,
+			Namespace: gs.Namespace,
 			Labels: map[string]string{
 				gameserver.AgonesGameServerNameLabel: gs.Name,
 			},

--- a/pkg/reconcilers/service_reconciler.go
+++ b/pkg/reconcilers/service_reconciler.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"github.com/Octops/gameserver-ingress-controller/internal/runtime"
 	"github.com/Octops/gameserver-ingress-controller/pkg/gameserver"
+	"github.com/Octops/gameserver-ingress-controller/pkg/record"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/tools/record"
 )
 
 type ServiceStore interface {
@@ -20,13 +20,13 @@ type ServiceStore interface {
 
 type ServiceReconciler struct {
 	store    ServiceStore
-	recorder *EventRecorder
+	recorder *record.EventRecorder
 }
 
-func NewServiceReconciler(store ServiceStore, recorder record.EventRecorder) *ServiceReconciler {
+func NewServiceReconciler(store ServiceStore, recorder *record.EventRecorder) *ServiceReconciler {
 	return &ServiceReconciler{
 		store:    store,
-		recorder: NewEventRecorder(recorder),
+		recorder: recorder,
 	}
 }
 
@@ -45,24 +45,24 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, gs *agonesv1.GameServ
 }
 
 func (r *ServiceReconciler) reconcileNotFound(ctx context.Context, gs *agonesv1.GameServer) (*corev1.Service, error) {
-	r.recorder.RecordCreating(gs, ServiceKind)
+	r.recorder.RecordCreating(gs, record.ServiceKind)
 
 	service, err := newService(gs)
 	if err != nil {
-		r.recorder.RecordFailed(gs, ServiceKind, err)
+		r.recorder.RecordFailed(gs, record.ServiceKind, err)
 		return nil, errors.Wrapf(err, "failed to create service for gameserver %s", gs.Name)
 	}
 
 	result, err := r.store.CreateService(ctx, service, metav1.CreateOptions{})
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
-			r.recorder.RecordFailed(gs, ServiceKind, err)
+			r.recorder.RecordFailed(gs, record.ServiceKind, err)
 			return nil, errors.Wrap(err, "failed to create service")
 		}
 		runtime.Logger().Debug(err)
 	}
 
-	r.recorder.RecordSuccess(gs, ServiceKind)
+	r.recorder.RecordSuccess(gs, record.ServiceKind)
 	return result, nil
 }
 

--- a/pkg/record/recorder.go
+++ b/pkg/record/recorder.go
@@ -1,22 +1,31 @@
-package reconcilers
+package record
 
 import (
 	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
 	"fmt"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
 )
 
 const (
 	IngressKind = "Ingress"
 	ServiceKind = "Service"
+
+	EventTypeNormal         string = "Normal"
+	EventTypeWarning               = "Warning"
+	ReasonReconcileFailed          = "Failed"
+	ReasonReconciled               = "Created"
+	ReasonReconcileCreating        = "Creating"
 )
 
-type EventRecorder struct {
-	recorder record.EventRecorder
+type Recorder interface {
+	Event(object runtime.Object, eventtype string, reason string, message string)
 }
 
-func NewEventRecorder(recorder record.EventRecorder) *EventRecorder {
+type EventRecorder struct {
+	recorder Recorder
+}
+
+func NewEventRecorder(recorder Recorder) *EventRecorder {
 	return &EventRecorder{recorder: recorder}
 }
 

--- a/pkg/stores/ingress_store.go
+++ b/pkg/stores/ingress_store.go
@@ -16,6 +16,10 @@ type ingressStore struct {
 	informer networkinginformers.IngressInformer
 }
 
+func newIngressStore(client kubernetes.Interface, informer networkinginformers.IngressInformer) *ingressStore {
+	return &ingressStore{client: client, informer: informer}
+}
+
 func (s *ingressStore) CreateIngress(ctx context.Context, ingress *networkingv1.Ingress, options metav1.CreateOptions) (*networkingv1.Ingress, error) {
 	result, err := s.client.NetworkingV1().Ingresses(ingress.Namespace).Create(ctx, ingress, options)
 	if err != nil {

--- a/pkg/stores/ingress_store.go
+++ b/pkg/stores/ingress_store.go
@@ -1,0 +1,39 @@
+package stores
+
+import (
+	"context"
+	"github.com/Octops/gameserver-ingress-controller/pkg/k8sutil"
+	"github.com/pkg/errors"
+	networkingv1 "k8s.io/api/networking/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	networkinginformers "k8s.io/client-go/informers/networking/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type ingressStore struct {
+	client   kubernetes.Interface
+	informer networkinginformers.IngressInformer
+}
+
+func (s *ingressStore) CreateIngress(ctx context.Context, ingress *networkingv1.Ingress, options metav1.CreateOptions) (*networkingv1.Ingress, error) {
+	result, err := s.client.NetworkingV1().Ingresses(ingress.Namespace).Create(ctx, ingress, options)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create Ingress %s", k8sutil.Namespaced(ingress))
+	}
+
+	return result, nil
+}
+
+func (s *ingressStore) GetIngress(name, namespace string) (*networkingv1.Ingress, error) {
+	result, err := s.informer.Lister().Ingresses(namespace).Get(name)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, err
+		}
+
+		return nil, errors.Wrapf(err, "error retrieving Ingress %s from namespace %s", name, namespace)
+	}
+
+	return result, nil
+}

--- a/pkg/stores/service_store.go
+++ b/pkg/stores/service_store.go
@@ -16,6 +16,10 @@ type serviceStore struct {
 	informer coreinformers.ServiceInformer
 }
 
+func newServiceStore(client kubernetes.Interface, informer coreinformers.ServiceInformer) *serviceStore {
+	return &serviceStore{client: client, informer: informer}
+}
+
 func (s *serviceStore) CreateService(ctx context.Context, service *corev1.Service, options metav1.CreateOptions) (*corev1.Service, error) {
 	result, err := s.client.CoreV1().Services(service.Namespace).Create(ctx, service, options)
 	if err != nil {

--- a/pkg/stores/service_store.go
+++ b/pkg/stores/service_store.go
@@ -1,0 +1,39 @@
+package stores
+
+import (
+	"context"
+	"github.com/Octops/gameserver-ingress-controller/pkg/k8sutil"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type serviceStore struct {
+	client   kubernetes.Interface
+	informer coreinformers.ServiceInformer
+}
+
+func (s *serviceStore) CreateService(ctx context.Context, service *corev1.Service, options metav1.CreateOptions) (*corev1.Service, error) {
+	result, err := s.client.CoreV1().Services(service.Namespace).Create(ctx, service, options)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create Service %s", k8sutil.Namespaced(service))
+	}
+
+	return result, nil
+}
+
+func (s *serviceStore) GetService(name, namespace string) (*corev1.Service, error) {
+	result, err := s.informer.Lister().Services(namespace).Get(name)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, err
+		}
+
+		return nil, errors.Wrapf(err, "error retrieving Service %s from namespace %s", name, namespace)
+	}
+
+	return result, nil
+}

--- a/pkg/stores/store.go
+++ b/pkg/stores/store.go
@@ -1,0 +1,45 @@
+package stores
+
+import (
+	"context"
+	"github.com/Octops/gameserver-ingress-controller/internal/runtime"
+	"github.com/pkg/errors"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+type Store struct {
+	*ingressStore
+	*serviceStore
+}
+
+func NewStore(ctx context.Context, client kubernetes.Interface) (*Store, error) {
+	factory := informers.NewSharedInformerFactory(client, 0)
+	ingresses := factory.Networking().V1().Ingresses()
+	services := factory.Core().V1().Services()
+
+	ingStore := &ingressStore{client: client, informer: ingresses}
+	svcStore := &serviceStore{client: client, informer: services}
+	store := &Store{ingStore, svcStore}
+
+	go factory.Start(ctx.Done())
+
+	if err := store.HasSynced(ctx); err != nil {
+		return nil, errors.Wrap(err, "store failed to sync cache")
+	}
+
+	return store, nil
+}
+
+func (s *Store) HasSynced(ctx context.Context) error {
+	svcInformer := s.serviceStore.informer.Informer()
+	ingInformer := s.ingressStore.informer.Informer()
+
+	runtime.Logger().WithField("component", "store").Info("waiting for cache to sync")
+	if !cache.WaitForCacheSync(ctx.Done(), svcInformer.HasSynced, ingInformer.HasSynced) {
+		return errors.New("timed out waiting for caches to sync")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Implement a dedicated store struct that will abstract the communication with K8S API when listing, getting and creating resources.

This way the code becomes more decoupled and testable.

The Store also use K8S SharedInformers instead of direct calls to the K8S API. That removes considerable the load put on the K8S API when not using the cache mechanism provided by client-go