### PR TITLE
Make Contour the recommended ingress controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ spec:
     metadata:
       annotations:
         octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress
+        octops-projectcontour.io/websocket-routes: "/" # required for Contour to enable websocket
         octops.io/gameserver-ingress-mode: "domain"
         octops.io/gameserver-ingress-domain: "example.com"
 ```
@@ -82,6 +83,7 @@ spec:
     metadata:
       annotations:
         octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress
+        octops-projectcontour.io/websocket-routes: "/" # required for Contour to enable websocket
         octops.io/gameserver-ingress-mode: "path"
         octops.io/gameserver-ingress-fqdn: servers.example.com
 ```
@@ -112,6 +114,7 @@ spec:
         region: us-east-1
       annotations:
         octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress
+        octops-projectcontour.io/websocket-routes: "/" # required for Contour to enable websocket
         # Required annotation used by the controller
         octops.io/gameserver-ingress-mode: "domain"
         octops.io/gameserver-ingress-domain: "example.com"
@@ -202,7 +205,7 @@ The same configuration works for Fleets and GameServers. Add the following annot
 # Fleet annotations using ingress routing mode: domain
 annotations:
   octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress
-  octops-projectcontour.io/websocket-routes: "/" # required by contour to enable websocket
+  octops-projectcontour.io/websocket-routes: "/" # required for Contour to enable websocket
   octops.io/gameserver-ingress-mode: "domain"
   octops.io/gameserver-ingress-domain: "example.com"
   octops.io/terminate-tls: "true"
@@ -213,7 +216,7 @@ annotations:
 # Fleet annotations using ingress routing mode: path
 annotations:
   octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress
-  octops-projectcontour.io/websocket-routes: "/" # required by contour to enable websocket
+  octops-projectcontour.io/websocket-routes: "/" # required for Contour to enable websocket
   octops.io/gameserver-ingress-mode: "path"
   octops.io/gameserver-ingress-fqdn: "servers.example.com"
   octops.io/terminate-tls: "true"

--- a/deploy/install.yaml
+++ b/deploy/install.yaml
@@ -69,7 +69,7 @@ spec:
     spec:
       serviceAccountName: octops
       containers:
-        - image: octops/gameserver-ingress-controller:latest # Tag latest is not ideal, check the latest released tag and replace
+        - image: octops/gameserver-ingress-controller:0.1.7 # Latest release
           name: controller
           ports:
             - containerPort: 30235

--- a/examples/fleet-dev.yaml
+++ b/examples/fleet-dev.yaml
@@ -30,7 +30,7 @@ spec:
 #        octops.io/gameserver-ingress-mode: "domain"
 #        octops.io/gameserver-ingress-domain: "example.com"
         octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress
-          octops-projectcontour.io/websocket-routes: "/" # required by contour to enable websocket
+        octops-projectcontour.io/websocket-routes: "/" # required for Contour to enable websocket
         octops.io/gameserver-ingress-mode: "path"
         octops.io/gameserver-ingress-fqdn: "servers.example.com"
     spec:

--- a/examples/fleet-dev.yaml
+++ b/examples/fleet-dev.yaml
@@ -29,9 +29,10 @@ spec:
       annotations:
 #        octops.io/gameserver-ingress-mode: "domain"
 #        octops.io/gameserver-ingress-domain: "example.com"
+        octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress
+          octops-projectcontour.io/websocket-routes: "/" # required by contour to enable websocket
         octops.io/gameserver-ingress-mode: "path"
         octops.io/gameserver-ingress-fqdn: "servers.example.com"
-        octops-kubernetes.io/ingress.class: "haproxy"
     spec:
       health:
         disabled: true

--- a/examples/fleet-domain.yaml
+++ b/examples/fleet-domain.yaml
@@ -27,7 +27,8 @@ spec:
         cluster: gke-1.17
         region: us-east-1
       annotations:
-        octops-kubernetes.io/ingress.class: "haproxy"
+        octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress
+        octops-projectcontour.io/websocket-routes: "/" # required by contour to enable websocket
         octops.io/gameserver-ingress-mode: "domain"
         octops.io/gameserver-ingress-domain: "example.com"
         #octops.io/tls-secret-name: "custom-secret"

--- a/examples/fleet-domain.yaml
+++ b/examples/fleet-domain.yaml
@@ -28,7 +28,7 @@ spec:
         region: us-east-1
       annotations:
         octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress
-        octops-projectcontour.io/websocket-routes: "/" # required by contour to enable websocket
+        octops-projectcontour.io/websocket-routes: "/" # required for Contour to enable websocket
         octops.io/gameserver-ingress-mode: "domain"
         octops.io/gameserver-ingress-domain: "example.com"
         #octops.io/tls-secret-name: "custom-secret"

--- a/examples/fleet-path.yaml
+++ b/examples/fleet-path.yaml
@@ -28,7 +28,7 @@ spec:
         region: us-east-1
       annotations:
         octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress
-          octops-projectcontour.io/websocket-routes: "/" # required by contour to enable websocket
+        octops-projectcontour.io/websocket-routes: "/" # required for Contour to enable websocket
         octops.io/gameserver-ingress-mode: "path"
         octops.io/gameserver-ingress-fqdn: "servers.example.com"
         #octops.io/tls-secret-name: "custom-secret"

--- a/examples/fleet-path.yaml
+++ b/examples/fleet-path.yaml
@@ -27,7 +27,8 @@ spec:
         cluster: gke-1.17
         region: us-east-1
       annotations:
-        octops-kubernetes.io/ingress.class: "haproxy"
+        octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress
+          octops-projectcontour.io/websocket-routes: "/" # required by contour to enable websocket
         octops.io/gameserver-ingress-mode: "path"
         octops.io/gameserver-ingress-fqdn: "servers.example.com"
         #octops.io/tls-secret-name: "custom-secret"

--- a/examples/quake/quake-fleet.yaml
+++ b/examples/quake/quake-fleet.yaml
@@ -56,7 +56,8 @@ spec:
         cluster: gke-1.17
         region: us-east-1
       annotations:
-        octops-kubernetes.io/ingress.class: "haproxy"
+        octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress
+        octops-projectcontour.io/websocket-routes: "/" # required by contour to enable websocket
         octops.io/gameserver-ingress-mode: "domain"
         octops.io/gameserver-ingress-domain: "arena.com"
         octops.io/terminate-tls: "true"

--- a/examples/quake/quake-fleet.yaml
+++ b/examples/quake/quake-fleet.yaml
@@ -57,7 +57,7 @@ spec:
         region: us-east-1
       annotations:
         octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress
-        octops-projectcontour.io/websocket-routes: "/" # required by contour to enable websocket
+        octops-projectcontour.io/websocket-routes: "/" # required for Contour to enable websocket
         octops.io/gameserver-ingress-mode: "domain"
         octops.io/gameserver-ingress-domain: "arena.com"
         octops.io/terminate-tls: "true"


### PR DESCRIPTION
This PR updates the required information that makes the Project Contour https://projectcontour.io/  the recommended ingress controller for Websocket based games.

After the feedback from the community of successful implementations using the Octops controller together with Contour/Envoy we are making it official on our documentation.