### PR TITLE
Consider Multiples States for Renconcile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ OCTOPS_BIN := bin/octops-controller
 
 IMAGE_REPO=octops/gameserver-ingress-controller
 DOCKER_IMAGE_TAG ?= octops/gameserver-ingress-controller:${VERSION}
-RELEASE_TAG=0.1.7
+RELEASE_TAG=0.1.8
 
 default: clean build
 

--- a/deploy/install.yaml
+++ b/deploy/install.yaml
@@ -69,7 +69,7 @@ spec:
     spec:
       serviceAccountName: octops
       containers:
-        - image: octops/gameserver-ingress-controller:0.1.7 # Latest release
+        - image: octops/gameserver-ingress-controller:0.1.8 # Latest release
           name: controller
           ports:
             - containerPort: 30235

--- a/pkg/gameserver/gameserver.go
+++ b/pkg/gameserver/gameserver.go
@@ -61,12 +61,27 @@ func HasAnnotation(gs *agonesv1.GameServer, annotation string) (string, bool) {
 	return "", false
 }
 
-func IsReady(gs *agonesv1.GameServer) bool {
+func IsShutdown(gs *agonesv1.GameServer) bool {
 	if gs == nil {
 		return false
 	}
 
-	return gs.Status.State == agonesv1.GameServerStateReady
+	return gs.Status.State == agonesv1.GameServerStateShutdown
+}
+
+func MustReconcile(gs *agonesv1.GameServer) bool {
+	if gs == nil {
+		return false
+	}
+
+	switch gs.Status.State {
+	case agonesv1.GameServerStateScheduled,
+		agonesv1.GameServerStateRequestReady,
+		agonesv1.GameServerStateReady:
+		return true
+	}
+
+	return false
 }
 
 func GetIngressRoutingMode(gs *agonesv1.GameServer) IngressRoutingMode {

--- a/pkg/handlers/gameserver_handler.go
+++ b/pkg/handlers/gameserver_handler.go
@@ -30,11 +30,9 @@ func NewGameSeverEventHandler(store *stores.Store, recorder *record.EventRecorde
 }
 
 func (h *GameSeverEventHandler) OnAdd(obj interface{}) error {
-	h.logger.WithField("event", "added").Infof("%s", obj.(*agonesv1.GameServer).Name)
-
 	gs := gameserver.FromObject(obj)
 
-	if err := h.Reconcile(gs); err != nil {
+	if err := h.Reconcile(h.logger.WithField("event", "added"), gs); err != nil {
 		h.logger.Error(err)
 	}
 
@@ -42,11 +40,9 @@ func (h *GameSeverEventHandler) OnAdd(obj interface{}) error {
 }
 
 func (h *GameSeverEventHandler) OnUpdate(_ interface{}, newObj interface{}) error {
-	h.logger.WithField("event", "updated").Infof("%s", newObj.(*agonesv1.GameServer).Name)
-
 	gs := gameserver.FromObject(newObj)
 
-	if err := h.Reconcile(gs); err != nil {
+	if err := h.Reconcile(h.logger.WithField("event", "updated"), gs); err != nil {
 		h.logger.Error(err)
 	}
 
@@ -54,7 +50,8 @@ func (h *GameSeverEventHandler) OnUpdate(_ interface{}, newObj interface{}) erro
 }
 
 func (h *GameSeverEventHandler) OnDelete(obj interface{}) error {
-	h.logger.WithField("event", "deleted").Infof("%s", obj.(*agonesv1.GameServer).Name)
+	gs := obj.(*agonesv1.GameServer)
+	h.logger.WithField("event", "deleted").Infof("%s/%s", gs.Namespace, gs.Name)
 
 	return nil
 }

--- a/pkg/handlers/gameserver_handler.go
+++ b/pkg/handlers/gameserver_handler.go
@@ -56,15 +56,23 @@ func (h *GameSeverEventHandler) OnDelete(obj interface{}) error {
 	return nil
 }
 
-func (h *GameSeverEventHandler) Reconcile(gs *agonesv1.GameServer) error {
+func (h *GameSeverEventHandler) Reconcile(logger *logrus.Entry, gs *agonesv1.GameServer) error {
 	if _, ok := gameserver.HasAnnotation(gs, gameserver.OctopsAnnotationIngressMode); !ok {
-		h.logger.Debugf("skipping gameserver %s/%s, annotation %s not present", gs.Namespace, gs.Name, gameserver.OctopsAnnotationIngressMode)
+		logger.Infof("skipping gameserver %s/%s, annotation %s not present", gs.Namespace, gs.Name, gameserver.OctopsAnnotationIngressMode)
 		return nil
 	}
 
-	if gameserver.IsReady(gs) == false {
-		msg := fmt.Sprintf("gameserver %s/%s not ready", gs.Namespace, gs.Name)
-		h.logger.Info(msg)
+	//If a game server is in a Shutdown state it will not trigger reconcile
+	if gameserver.IsShutdown(gs) {
+		logger.WithField("event", "shutdown").Infof("%s/%s", gs.Namespace, gs.Name)
+
+		return nil
+	}
+
+	//Only Scheduled, ReadyState and Ready game server states will trigger reconcile
+	if gameserver.MustReconcile(gs) == false {
+		msg := fmt.Sprintf("%s/%s/%s not reconciled, waiting for Scheduled, ReadyState or Ready state", gs.Namespace, gs.Name, gs.Status.State)
+		logger.Info(msg)
 
 		return nil
 	}
@@ -79,6 +87,9 @@ func (h *GameSeverEventHandler) Reconcile(gs *agonesv1.GameServer) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to reconcile ingress %s/%s", gs.Namespace, gs.Name)
 	}
+
+	msg := fmt.Sprintf("%s/%s/%s reconciled", gs.Namespace, gs.Name, gs.Status.State)
+	logger.Info(msg)
 
 	return nil
 }

--- a/pkg/handlers/gameserver_handler.go
+++ b/pkg/handlers/gameserver_handler.go
@@ -58,7 +58,7 @@ func (h *GameSeverEventHandler) OnDelete(obj interface{}) error {
 
 func (h *GameSeverEventHandler) Reconcile(logger *logrus.Entry, gs *agonesv1.GameServer) error {
 	if _, ok := gameserver.HasAnnotation(gs, gameserver.OctopsAnnotationIngressMode); !ok {
-		logger.Infof("skipping gameserver %s/%s, annotation %s not present", gs.Namespace, gs.Name, gameserver.OctopsAnnotationIngressMode)
+		logger.Infof("skipping %s/%s, annotation %s not present", gs.Namespace, gs.Name, gameserver.OctopsAnnotationIngressMode)
 		return nil
 	}
 


### PR DESCRIPTION
This PR implements a feature that triggers Reconcile only for a set of States: Scheduled, RequestReady and Ready

Additionally, it improves logging during the reconcile process.

Considering the Scheduled and RequestReady states, Ingresses will be provisioned before the game server is set Ready. That means, when allocating a game server it will be available to the player immediately.
