### PR TITLE
Add missing verb to RBAC

### DIFF
--- a/deploy/install.yaml
+++ b/deploy/install.yaml
@@ -33,7 +33,7 @@ rules:
     verbs: ["list", "get", "create", "delete", "watch"]
   - apiGroups: ["agones.dev"]
     resources: ["gameservers","fleets"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get","update", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This fix a missing RBAC verb required by the controller to update game servers and set the annotation `octops.io/ingress-ready`.