### PR TITLE
Support multiple hosts or domains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ OCTOPS_BIN := bin/octops-controller
 
 IMAGE_REPO=octops/gameserver-ingress-controller
 DOCKER_IMAGE_TAG ?= octops/gameserver-ingress-controller:${VERSION}
-RELEASE_TAG=0.2.3
+RELEASE_TAG=0.2.4
 
 default: clean build
 
@@ -98,6 +98,10 @@ latest: docker
 	docker push $(IMAGE_REPO):latest
 
 release: latest
+	docker tag $(DOCKER_IMAGE_TAG) $(IMAGE_REPO):$(RELEASE_TAG)
+	docker push $(IMAGE_REPO):$(RELEASE_TAG)
+
+beta: docker
 	docker tag $(DOCKER_IMAGE_TAG) $(IMAGE_REPO):$(RELEASE_TAG)
 	docker push $(IMAGE_REPO):$(RELEASE_TAG)
 

--- a/examples/fleet-domain.yaml
+++ b/examples/fleet-domain.yaml
@@ -30,7 +30,8 @@ spec:
         octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress
         octops-projectcontour.io/websocket-routes: "/" # required for Contour to enable websocket
         octops.io/gameserver-ingress-mode: "domain"
-        octops.io/gameserver-ingress-domain: "example.com"
+        octops.io/gameserver-ingress-domain: "example.com,example.gg"
+#        octops.io/gameserver-ingress-domain: "example.com"
         #octops.io/tls-secret-name: "custom-secret"
         octops.io/terminate-tls: "true"
         octops.io/issuer-tls-name: "selfsigned-issuer"

--- a/examples/fleet-path.yaml
+++ b/examples/fleet-path.yaml
@@ -29,6 +29,7 @@ spec:
       annotations:
         octops-kubernetes.io/ingress.class: "contour" #required for Contour to handle ingress
         octops.io/gameserver-ingress-mode: "path"
+#        octops.io/gameserver-ingress-fqdn: "servers.example.com,servers.example.gg"
         octops.io/gameserver-ingress-fqdn: "servers.example.com"
         octops-projectcontour.io/websocket-routes: "/{{ .Name }}" #required for Contour to enable websocket, use template to define values
         #octops.io/tls-secret-name: "custom-secret"

--- a/pkg/gameserver/gameserver.go
+++ b/pkg/gameserver/gameserver.go
@@ -23,8 +23,9 @@ const (
 	CertManagerAnnotationIssuer = "cert-manager.io/cluster-issuer"
 	AgonesGameServerNameLabel   = "agones.dev/gameserver"
 
-	ErrGameServerAnnotationEmpty = "gameserver %s/%s has annotation %s but it is empty"
-	ErrIngressRoutingModeEmpty   = "ingress routing mode %s requires the annotation %s to be set"
+	ErrGameServerAnnotationMissing = "gameserver %s/%s is missing annotation %s"
+	ErrGameServerAnnotationEmpty   = "gameserver %s/%s has annotation %s but it is empty"
+	ErrIngressRoutingModeEmpty     = "ingress routing mode %s requires the annotation %s to be set on gameserver %s/%s"
 )
 
 func (m IngressRoutingMode) String() string {

--- a/pkg/reconcilers/ingress_options.go
+++ b/pkg/reconcilers/ingress_options.go
@@ -125,7 +125,7 @@ func WithTLS(mode gameserver.IngressRoutingMode) IngressOption {
 
 				tls[i] = networkingv1.IngressTLS{
 					Hosts: []string{
-						fmt.Sprintf("%s.%s", gs.Name, f),
+						strings.TrimSpace(f),
 					},
 					SecretName: tlsSecret,
 				}

--- a/pkg/reconcilers/ingress_options_test.go
+++ b/pkg/reconcilers/ingress_options_test.go
@@ -2,10 +2,11 @@ package reconcilers
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/Octops/gameserver-ingress-controller/pkg/gameserver"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func Test_WithCustomAnnotationsTemplate(t *testing.T) {
@@ -336,7 +337,7 @@ func Test_WithTLS(t *testing.T) {
 				gameserver.OctopsAnnotationIngressDomain: "example.com",
 			},
 			routingMode: gameserver.IngressRoutingModeDomain,
-			expected:    "simple-gameserver-no-custom-tls",
+			expected:    "example-com-simple-gameserver-no-custom-tls",
 		},
 		{
 			name:   "no custom secret name for path mode",
@@ -345,7 +346,7 @@ func Test_WithTLS(t *testing.T) {
 				gameserver.OctopsAnnotationIngressFQDN: "www.example.com",
 			},
 			routingMode: gameserver.IngressRoutingModePath,
-			expected:    "simple-gameserver-no-custom-tls",
+			expected:    "www-example-com-simple-gameserver-no-custom-tls",
 		},
 		{
 			name:   "empty secret annotation for domain mode",

--- a/pkg/reconcilers/ingress_reconciler_test.go
+++ b/pkg/reconcilers/ingress_reconciler_test.go
@@ -149,7 +149,7 @@ func Test_NewIngress_PathRoutingMode(t *testing.T) {
 			tls := []networkingv1.IngressTLS{
 				{
 					Hosts: []string{
-						fmt.Sprintf("%s.%s", gs.Name, fqdn),
+						strings.TrimSpace(fqdn),
 					},
 					SecretName: strings.ReplaceAll(fmt.Sprintf("%s-%s-tls", fqdn, gs.Name), ".", "-"),
 				},

--- a/pkg/reconcilers/ingress_reconciler_test.go
+++ b/pkg/reconcilers/ingress_reconciler_test.go
@@ -1,13 +1,16 @@
 package reconcilers
 
 import (
-	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
 	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
 	"github.com/Octops/gameserver-ingress-controller/pkg/gameserver"
 	"github.com/stretchr/testify/require"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strconv"
-	"testing"
 )
 
 func Test_NewIngress_DomainRoutingMode(t *testing.T) {
@@ -45,8 +48,37 @@ func Test_NewIngress_DomainRoutingMode(t *testing.T) {
 			issuerName := gameserver.GetTLSCertIssuer(gs)
 			host := fmt.Sprintf("%s.%s", gs.Name, gs.Annotations[gameserver.OctopsAnnotationIngressDomain])
 			ref := metav1.NewControllerRef(gs, agonesv1.SchemeGroupVersion.WithKind("GameServer"))
-			tls := newIngressTLS(host, gs.Name)
-			rules := newIngressRule(host, "/", gs.Name, gameserver.GetGameServerPort(gs).Port)
+			tls := []networkingv1.IngressTLS{
+				{
+					Hosts: []string{
+						host,
+					},
+					SecretName: strings.ReplaceAll(fmt.Sprintf("%s-%s-tls", domain, gs.Name), ".", "-"),
+				},
+			}
+			rules := []networkingv1.IngressRule{
+				{
+					Host: strings.TrimSpace(host),
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Path:     "/",
+									PathType: &defaultPathType,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: gs.Name,
+											Port: networkingv1.ServiceBackendPort{
+												Number: gameserver.GetGameServerPort(gs).Port,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
 
 			opts := []IngressOption{
 				WithCustomAnnotations(),
@@ -114,8 +146,38 @@ func Test_NewIngress_PathRoutingMode(t *testing.T) {
 			issuerName := gameserver.GetTLSCertIssuer(gs)
 
 			ref := metav1.NewControllerRef(gs, agonesv1.SchemeGroupVersion.WithKind("GameServer"))
-			tls := newIngressTLS(fqdn, gs.Name)
-			rules := newIngressRule(gs.Annotations[gameserver.OctopsAnnotationIngressFQDN], "/"+gs.Name, gs.Name, gameserver.GetGameServerPort(gs).Port)
+			tls := []networkingv1.IngressTLS{
+				{
+					Hosts: []string{
+						fmt.Sprintf("%s.%s", gs.Name, fqdn),
+					},
+					SecretName: strings.ReplaceAll(fmt.Sprintf("%s-%s-tls", fqdn, gs.Name), ".", "-"),
+				},
+			}
+			host := gs.Annotations[gameserver.OctopsAnnotationIngressFQDN]
+			rules := []networkingv1.IngressRule{
+				{
+					Host: strings.TrimSpace(host),
+					IngressRuleValue: networkingv1.IngressRuleValue{
+						HTTP: &networkingv1.HTTPIngressRuleValue{
+							Paths: []networkingv1.HTTPIngressPath{
+								{
+									Path:     "/" + gs.Name,
+									PathType: &defaultPathType,
+									Backend: networkingv1.IngressBackend{
+										Service: &networkingv1.IngressServiceBackend{
+											Name: gs.Name,
+											Port: networkingv1.ServiceBackendPort{
+												Number: gameserver.GetGameServerPort(gs).Port,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
 
 			opts := []IngressOption{
 				WithCustomAnnotations(),


### PR DESCRIPTION
This is a feature request described on https://github.com/Octops/gameserver-ingress-controller/issues/43

This feature adds the ability to expose the game server using multiples domains or hosts. The feature is present on the two available routing modes Path and Domain. The same annotation must be used inform the FQDN or the domain only.

```yaml
# routing mode path
annotations:
  octops.io/gameserver-ingress-mode: "path"
  octops.io/gameserver-ingress-fqdn: "servers.example.com,servers.example.gg"
```

```yaml
# routing mode domain
annotations:
  octops.io/gameserver-ingress-mode: "domain"
  octops.io/gameserver-ingress-domain: "example.com,example.gg"
```

The current implementation can be tested using following image tag:
`octops/gameserver-ingress-controller:rc-0.2.4`