### PR TITLE
Support ingress class name in ingress spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ OCTOPS_BIN := bin/octops-controller
 
 IMAGE_REPO=octops/gameserver-ingress-controller
 DOCKER_IMAGE_TAG ?= octops/gameserver-ingress-controller:${VERSION}
-RELEASE_TAG=0.2.9
+RELEASE_TAG=0.3.0
 
 default: clean build
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ spec:
   template:
     metadata:
       annotations:
-        octops-kubernetes.io/ingress.class: "contour" #required for Contour to handle ingress
+        octops.io/ingress-class-name: "contour" #required for Contour to handle ingress
         octops-projectcontour.io/websocket-routes: "/" #required for Contour to enable websocket
         octops.io/gameserver-ingress-mode: "domain"
         octops.io/gameserver-ingress-domain: "example.com"
@@ -84,7 +84,7 @@ spec:
   template:
     metadata:
       annotations:
-        octops-kubernetes.io/ingress.class: "contour" #required for Contour to handle ingress
+        octops.io/ingress-class-name: "contour" #required for Contour to handle ingress
         octops-projectcontour.io/websocket-routes: "/{{ .Name }}" #required for Contour to enable websocket for exact path. This is a template that the controller will replace by the name of the game server
         octops.io/gameserver-ingress-mode: "path"
         octops.io/gameserver-ingress-fqdn: servers.example.com
@@ -115,7 +115,7 @@ spec:
         cluster: gke-1.24
         region: us-east-1
       annotations:
-        octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress
+        octops.io/ingress-class-name: "contour" # required for Contour to handle ingress
         octops-projectcontour.io/websocket-routes: "/" # required for Contour to enable websocket
         # Required annotation used by the controller
         octops.io/gameserver-ingress-mode: "domain"
@@ -165,6 +165,7 @@ The table below shows how the information from the game server is used to compos
 | annotation: octops.io/issuer-tls-name           |  name of the ClusterIssuer  |
 | annotation: octops-[custom-annotation]          |      custom-annotation      |
 | annotation: octops.io/tls-secret-name           |    custom ingress secret    |
+| annotation: octops.io/ingress-class-name        |   ingressClassName field    |
 
 **Support for Multiple Domains**
 
@@ -264,13 +265,13 @@ https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 - **octops.io/gameserver-ingress-fqdn:** full domain name where gameservers will be accessed based on the URL path.
 - **octops.io/terminate-tls:** it determines if the ingress will terminate TLS. If set to "false" it means that TLS will be terminated at the load balancer. In this case there won't be a certificate issued by the local cert-manager.
 - **octops.io/issuer-tls-name:** required if `terminate-tls=true` and certificates are provisioned by CertManager. This is the name of the ClusterIssuer that cert-manager will use when creating the certificate for the ingress.
-- **octops.io/tls-secret-name:** ignore CertManager and sets the secret to be used by the Ingress, requires `terminate-tls=true`. This secret might be provisioned by other means. This is specially useful for wildcard certificates that have been generated or acquired using a different process.
+- **octops.io/ingress-class-name:** Defines the ingress class name to be used e.g ("contour", "nginx", "traefik")
 
 The same configuration works for Fleets and GameServers. Add the following annotations to your manifest:
 ```yaml
 # Fleet annotations using ingress routing mode: domain
 annotations:
-  octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress
+  octops.io/ingress-class-name: "contour" # required for Contour to handle ingress
   octops-projectcontour.io/websocket-routes: "/" # required for Contour to enable websocket
   octops.io/gameserver-ingress-mode: "domain"
   octops.io/gameserver-ingress-domain: "example.com"
@@ -281,7 +282,7 @@ annotations:
 ```yaml
 # Fleet annotations using ingress routing mode: path
 annotations:
-  octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress
+  octops.io/ingress-class-name: "contour" # required for Contour to handle ingress
   octops-projectcontour.io/websocket-routes: "/" # required for Contour to enable websocket
   octops.io/gameserver-ingress-mode: "path"
   octops.io/gameserver-ingress-fqdn: "servers.example.com"

--- a/deploy/install.yaml
+++ b/deploy/install.yaml
@@ -69,7 +69,7 @@ spec:
     spec:
       serviceAccountName: octops-ingress-controller
       containers:
-        - image: octops/gameserver-ingress-controller:0.2.9 # Latest release
+        - image: octops/gameserver-ingress-controller:0.3.0 # Latest release
           name: controller
           ports:
             - containerPort: 30235

--- a/pkg/gameserver/gameserver.go
+++ b/pkg/gameserver/gameserver.go
@@ -19,6 +19,8 @@ const (
 	OctopsAnnotationCustomPrefix           = "octops-"
 	OctopsAnnotationCustomServicePrefix    = "octops.service-"
 	OctopsAnnotationGameServerIngressReady = "octops.io/ingress-ready"
+	OctopsAnnotationIngressClassName       = "octops.io/ingress-class-name"
+	OctopsAnnotationIngressClassNameLegacy = "octops-kubernetes.io/ingress.class"
 
 	CertManagerAnnotationIssuer = "cert-manager.io/cluster-issuer"
 	AgonesGameServerNameLabel   = "agones.dev/gameserver"
@@ -98,6 +100,18 @@ func GetIngressRoutingMode(gs *agonesv1.GameServer) IngressRoutingMode {
 func GetTLSCertIssuer(gs *agonesv1.GameServer) string {
 	if name, ok := HasAnnotation(gs, OctopsAnnotationIssuerName); ok {
 		return name
+	}
+
+	return ""
+}
+
+func GetIngressClassName(gs *agonesv1.GameServer) string {
+	if className, ok := HasAnnotation(gs, OctopsAnnotationIngressClassName); ok {
+		return className
+	}
+
+	if className, ok := HasAnnotation(gs, OctopsAnnotationIngressClassNameLegacy); ok {
+		return className
 	}
 
 	return ""

--- a/pkg/reconcilers/ingress_options.go
+++ b/pkg/reconcilers/ingress_options.go
@@ -237,6 +237,20 @@ func WithTLSCertIssuer(issuerName string) IngressOption {
 	}
 }
 
+func WithIngressClassName(className string) IngressOption {
+	return func(gs *agonesv1.GameServer, ingress *networkingv1.Ingress) error {
+		if className == "" {
+			return errors.Errorf("annotation %s for %s must not be empty, check your Fleet or GameServer manifest.",
+				gameserver.OctopsAnnotationIngressClassName, gs.Name)
+		}
+
+		//TODO: The order that Options functions run matters, an Ingress can't have the annotation and the Class set in the spec
+		delete(ingress.Annotations, "kubernetes.io/ingress.class")
+		ingress.Spec.IngressClassName = &className
+		return nil
+	}
+}
+
 func newIngressRule(host, path, serviceName string, port int32) networkingv1.IngressRule {
 	return networkingv1.IngressRule{
 		Host: strings.TrimSpace(host),

--- a/pkg/reconcilers/ingress_reconciler.go
+++ b/pkg/reconcilers/ingress_reconciler.go
@@ -49,12 +49,14 @@ func (r *IngressReconciler) reconcileNotFound(ctx context.Context, gs *agonesv1.
 
 	mode := gameserver.GetIngressRoutingMode(gs)
 	issuer := gameserver.GetTLSCertIssuer(gs)
+	className := gameserver.GetIngressClassName(gs)
 
 	opts := []IngressOption{
 		WithCustomAnnotations(),
 		WithCustomAnnotationsTemplate(),
 		WithIngressRule(mode),
 		WithTLS(mode),
+		WithIngressClassName(className),
 	}
 
 	if issuer != "" {


### PR DESCRIPTION
## What?
- Add standard annotation for specifying the Ingress class name
- Set `ingressClassName` field in the Ingress Object
- Keep backwards compatibilty with the old annotation
- Always drop `kubernetes.io/ingress-class` annotation

## Why?
- It's prefereable to use the Ingress object attribute instead of the annotation.
- Kubernetes 1.25+ won't support `ingressClassName` and the annotation `kubernetes.io/ingress.class` to be set simultaneously
