### PR TITLE
Do not create TLS if not necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ OCTOPS_BIN := bin/octops-controller
 
 IMAGE_REPO=octops/gameserver-ingress-controller
 DOCKER_IMAGE_TAG ?= octops/gameserver-ingress-controller:${VERSION}
-RELEASE_TAG=0.2.5
+RELEASE_TAG=0.2.6
 
 default: clean build
 

--- a/README.md
+++ b/README.md
@@ -105,14 +105,14 @@ kind: Fleet
 metadata:
   name: octops # the name of your fleet
   labels: # optional labels
-    cluster: gke-1.22
+    cluster: gke-1.24
     region: us-east-1
 spec:
   replicas: 3
   template:
     metadata:
       labels: # optional labels
-        cluster: gke-1.22
+        cluster: gke-1.24
         region: us-east-1
       annotations:
         octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress

--- a/deploy/install.yaml
+++ b/deploy/install.yaml
@@ -69,7 +69,7 @@ spec:
     spec:
       serviceAccountName: octops-ingress-controller
       containers:
-        - image: octops/gameserver-ingress-controller:0.2.5 # Latest release
+        - image: octops/gameserver-ingress-controller:0.2.6 # Latest release
           name: controller
           ports:
             - containerPort: 30235

--- a/examples/fleet-dev.yaml
+++ b/examples/fleet-dev.yaml
@@ -17,7 +17,7 @@ kind: Fleet
 metadata:
   name: octops
   labels:
-    cluster: gke-1.22
+    cluster: gke-1.24
     region: us-east-1
 spec:
 #  strategy:
@@ -26,7 +26,7 @@ spec:
   template:
     metadata:
       labels:
-        cluster: gke-1.22
+        cluster: gke-1.24
         region: us-east-1
       annotations:
 #        octops.io/gameserver-ingress-mode: "domain"

--- a/examples/fleet-domain.yaml
+++ b/examples/fleet-domain.yaml
@@ -17,14 +17,14 @@ kind: Fleet
 metadata:
   name: octops-domain
   labels:
-    cluster: gke-1.17
+    cluster: gke-1.24
     region: us-east-1
 spec:
   replicas: 3
   template:
     metadata:
       labels:
-        cluster: gke-1.17
+        cluster: gke-1.24
         region: us-east-1
       annotations:
         octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress

--- a/examples/fleet-path.yaml
+++ b/examples/fleet-path.yaml
@@ -17,14 +17,14 @@ kind: Fleet
 metadata:
   name: octops-path
   labels:
-    cluster: gke-1.17
+    cluster: gke-1.24
     region: us-east-1
 spec:
   replicas: 3
   template:
     metadata:
       labels:
-        cluster: gke-1.17
+        cluster: gke-1.24
         region: us-east-1
       annotations:
         octops-kubernetes.io/ingress.class: "contour" #required for Contour to handle ingress

--- a/examples/quake/quake-fleet.yaml
+++ b/examples/quake/quake-fleet.yaml
@@ -46,14 +46,14 @@ kind: Fleet
 metadata:
   name: octops
   labels:
-    cluster: gke-1.17
+    cluster: gke-1.24
     region: us-east-1
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        cluster: gke-1.17
+        cluster: gke-1.24
         region: us-east-1
       annotations:
         octops-kubernetes.io/ingress.class: "contour" # required for Contour to handle ingress

--- a/pkg/handlers/gameserver_handler.go
+++ b/pkg/handlers/gameserver_handler.go
@@ -75,7 +75,7 @@ func (h *GameSeverEventHandler) Reconcile(ctx context.Context, logger *logrus.En
 
 	//Only Scheduled, ReadyState and Ready game server states will trigger reconcile
 	if gameserver.MustReconcile(gs) == false {
-		msg := fmt.Sprintf("%s/%s/%s not reconciled, waiting for Scheduled, ReadyState or Ready state", gs.Namespace, gs.Name, gs.Status.State)
+		msg := fmt.Sprintf("%s/%s/%s not reconciled, requires Scheduled, ReadyState or Ready state", gs.Namespace, gs.Name, gs.Status.State)
 		logger.Info(msg)
 
 		return nil

--- a/pkg/reconcilers/ingress_options.go
+++ b/pkg/reconcilers/ingress_options.go
@@ -75,6 +75,17 @@ func WithCustomAnnotations() IngressOption {
 
 func WithTLS(mode gameserver.IngressRoutingMode) IngressOption {
 	return func(gs *agonesv1.GameServer, ingress *networkingv1.Ingress) error {
+		terminate, ok := gameserver.HasAnnotation(gs, gameserver.OctopsAnnotationTerminateTLS)
+		if !ok || len(terminate) == 0 {
+			return nil
+		}
+
+		if terminateTLS, err := strconv.ParseBool(terminate); err != nil {
+			return errors.Errorf("annotation %s for %s must be \"true\" or \"false\"", gameserver.OctopsAnnotationTerminateTLS, gs.Name)
+		} else if terminateTLS == false {
+			return nil
+		}
+
 		errMsgInvalidAnnotation := func(mode, annotation, namespace, name string) error {
 			return errors.Errorf(gameserver.ErrIngressRoutingModeEmpty, mode, annotation, namespace, name)
 		}

--- a/pkg/reconcilers/ingress_options_test.go
+++ b/pkg/reconcilers/ingress_options_test.go
@@ -318,6 +318,7 @@ func Test_WithTLS(t *testing.T) {
 			name:   "with custom secret name for domain mode",
 			gsName: "simple-gameserver-with-custom",
 			annotations: map[string]string{
+				gameserver.OctopsAnnotationTerminateTLS:   "true",
 				gameserver.OctopsAnnotationIngressDomain:  "example.com",
 				gameserver.OctopsAnnotationsTLSSecretName: "my_custom_secret_name",
 			},
@@ -333,6 +334,7 @@ func Test_WithTLS(t *testing.T) {
 			name:   "with custom secret name for path mode",
 			gsName: "simple-gameserver-with-custom",
 			annotations: map[string]string{
+				gameserver.OctopsAnnotationTerminateTLS:   "true",
 				gameserver.OctopsAnnotationIngressFQDN:    "www.example.com",
 				gameserver.OctopsAnnotationsTLSSecretName: "my_custom_secret_name",
 			},
@@ -348,6 +350,7 @@ func Test_WithTLS(t *testing.T) {
 			name:   "no custom secret name for domain mode",
 			gsName: "simple-gameserver-no-custom",
 			annotations: map[string]string{
+				gameserver.OctopsAnnotationTerminateTLS:  "true",
 				gameserver.OctopsAnnotationIngressDomain: "example.com",
 			},
 			routingMode: gameserver.IngressRoutingModeDomain,
@@ -362,6 +365,7 @@ func Test_WithTLS(t *testing.T) {
 			name:   "no custom secret name for domain mode with multiple domains",
 			gsName: "simple-gameserver-no-custom",
 			annotations: map[string]string{
+				gameserver.OctopsAnnotationTerminateTLS:  "true",
 				gameserver.OctopsAnnotationIngressDomain: "example.com,example.gg",
 			},
 			routingMode: gameserver.IngressRoutingModeDomain,
@@ -380,7 +384,8 @@ func Test_WithTLS(t *testing.T) {
 			name:   "no custom secret name for path mode",
 			gsName: "simple-gameserver-no-custom",
 			annotations: map[string]string{
-				gameserver.OctopsAnnotationIngressFQDN: "www.example.com",
+				gameserver.OctopsAnnotationTerminateTLS: "true",
+				gameserver.OctopsAnnotationIngressFQDN:  "www.example.com",
 			},
 			routingMode: gameserver.IngressRoutingModePath,
 			expected: []networkingv1.IngressTLS{
@@ -394,7 +399,8 @@ func Test_WithTLS(t *testing.T) {
 			name:   "no custom secret name for path mode with multiple domains",
 			gsName: "simple-gameserver-no-custom",
 			annotations: map[string]string{
-				gameserver.OctopsAnnotationIngressFQDN: "www.example.com,www.example.gg",
+				gameserver.OctopsAnnotationTerminateTLS: "true",
+				gameserver.OctopsAnnotationIngressFQDN:  "www.example.com,www.example.gg",
 			},
 			routingMode: gameserver.IngressRoutingModePath,
 			expected: []networkingv1.IngressTLS{
@@ -412,6 +418,7 @@ func Test_WithTLS(t *testing.T) {
 			name:   "empty secret annotation for domain mode",
 			gsName: "simple-gameserver-no-custom",
 			annotations: map[string]string{
+				gameserver.OctopsAnnotationTerminateTLS:   "true",
 				gameserver.OctopsAnnotationIngressDomain:  "example.com",
 				gameserver.OctopsAnnotationsTLSSecretName: "",
 			},
@@ -424,6 +431,7 @@ func Test_WithTLS(t *testing.T) {
 			name:   "empty secret annotation for path mode",
 			gsName: "simple-gameserver-no-custom",
 			annotations: map[string]string{
+				gameserver.OctopsAnnotationTerminateTLS:   "true",
 				gameserver.OctopsAnnotationIngressFQDN:    "www.example.com",
 				gameserver.OctopsAnnotationsTLSSecretName: "",
 			},
@@ -433,18 +441,22 @@ func Test_WithTLS(t *testing.T) {
 			wantErr:     true,
 		},
 		{
-			name:        "error routing mode empty for path mode",
-			gsName:      "simple-gameserver-no-custom",
-			annotations: map[string]string{},
+			name:   "error routing mode empty for path mode",
+			gsName: "simple-gameserver-no-custom",
+			annotations: map[string]string{
+				gameserver.OctopsAnnotationTerminateTLS: "true",
+			},
 			routingMode: gameserver.IngressRoutingModePath,
 			expected:    []networkingv1.IngressTLS{},
 			err:         errors.Errorf(gameserver.ErrIngressRoutingModeEmpty, gameserver.IngressRoutingModePath, gameserver.OctopsAnnotationIngressFQDN, "default", "simple-gameserver-no-custom"),
 			wantErr:     true,
 		},
 		{
-			name:        "error routing mode empty for domain mode",
-			gsName:      "simple-gameserver-no-custom",
-			annotations: map[string]string{},
+			name:   "error routing mode empty for domain mode",
+			gsName: "simple-gameserver-no-custom",
+			annotations: map[string]string{
+				gameserver.OctopsAnnotationTerminateTLS: "true",
+			},
 			routingMode: gameserver.IngressRoutingModeDomain,
 			expected:    []networkingv1.IngressTLS{},
 			err:         errors.Errorf(gameserver.ErrIngressRoutingModeEmpty, gameserver.IngressRoutingModeDomain, gameserver.OctopsAnnotationIngressDomain, "default", "simple-gameserver-no-custom"),

--- a/pkg/reconcilers/ingress_reconciler_test.go
+++ b/pkg/reconcilers/ingress_reconciler_test.go
@@ -48,14 +48,19 @@ func Test_NewIngress_DomainRoutingMode(t *testing.T) {
 			issuerName := gameserver.GetTLSCertIssuer(gs)
 			host := fmt.Sprintf("%s.%s", gs.Name, gs.Annotations[gameserver.OctopsAnnotationIngressDomain])
 			ref := metav1.NewControllerRef(gs, agonesv1.SchemeGroupVersion.WithKind("GameServer"))
-			tls := []networkingv1.IngressTLS{
-				{
-					Hosts: []string{
-						host,
+
+			var tls []networkingv1.IngressTLS
+			if tc.terminateTLS {
+				tls = []networkingv1.IngressTLS{
+					{
+						Hosts: []string{
+							host,
+						},
+						SecretName: strings.ReplaceAll(fmt.Sprintf("%s-%s-tls", domain, gs.Name), ".", "-"),
 					},
-					SecretName: strings.ReplaceAll(fmt.Sprintf("%s-%s-tls", domain, gs.Name), ".", "-"),
-				},
+				}
 			}
+
 			rules := []networkingv1.IngressRule{
 				{
 					Host: strings.TrimSpace(host),
@@ -146,14 +151,18 @@ func Test_NewIngress_PathRoutingMode(t *testing.T) {
 			issuerName := gameserver.GetTLSCertIssuer(gs)
 
 			ref := metav1.NewControllerRef(gs, agonesv1.SchemeGroupVersion.WithKind("GameServer"))
-			tls := []networkingv1.IngressTLS{
-				{
-					Hosts: []string{
-						strings.TrimSpace(fqdn),
+			var tls []networkingv1.IngressTLS
+			if tc.terminateTLS {
+				tls = []networkingv1.IngressTLS{
+					{
+						Hosts: []string{
+							strings.TrimSpace(fqdn),
+						},
+						SecretName: strings.ReplaceAll(fmt.Sprintf("%s-%s-tls", fqdn, gs.Name), ".", "-"),
 					},
-					SecretName: strings.ReplaceAll(fmt.Sprintf("%s-%s-tls", fqdn, gs.Name), ".", "-"),
-				},
+				}
 			}
+
 			host := gs.Annotations[gameserver.OctopsAnnotationIngressFQDN]
 			rules := []networkingv1.IngressRule{
 				{


### PR DESCRIPTION
When terminate-tls annotation is set to false there should not be a section in the Ingress resources that sets thet TLS.
