### PR TITLE
Fix TLS Secret Logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ OCTOPS_BIN := bin/octops-controller
 
 IMAGE_REPO=octops/gameserver-ingress-controller
 DOCKER_IMAGE_TAG ?= octops/gameserver-ingress-controller:${VERSION}
-RELEASE_TAG=0.2.7
+RELEASE_TAG=0.2.8
 
 default: clean build
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ OCTOPS_BIN := bin/octops-controller
 
 IMAGE_REPO=octops/gameserver-ingress-controller
 DOCKER_IMAGE_TAG ?= octops/gameserver-ingress-controller:${VERSION}
-RELEASE_TAG=0.2.8
+RELEASE_TAG=0.2.9
 
 default: clean build
 

--- a/deploy/install.yaml
+++ b/deploy/install.yaml
@@ -69,7 +69,7 @@ spec:
     spec:
       serviceAccountName: octops-ingress-controller
       containers:
-        - image: octops/gameserver-ingress-controller:0.2.8 # Latest release
+        - image: octops/gameserver-ingress-controller:0.2.9 # Latest release
           name: controller
           ports:
             - containerPort: 30235

--- a/deploy/install.yaml
+++ b/deploy/install.yaml
@@ -69,7 +69,7 @@ spec:
     spec:
       serviceAccountName: octops-ingress-controller
       containers:
-        - image: octops/gameserver-ingress-controller:0.2.7 # Latest release
+        - image: octops/gameserver-ingress-controller:0.2.8 # Latest release
           name: controller
           ports:
             - containerPort: 30235

--- a/pkg/reconcilers/ingress_reconciler.go
+++ b/pkg/reconcilers/ingress_reconciler.go
@@ -55,7 +55,10 @@ func (r *IngressReconciler) reconcileNotFound(ctx context.Context, gs *agonesv1.
 		WithCustomAnnotationsTemplate(),
 		WithIngressRule(mode),
 		WithTLS(mode),
-		WithTLSCertIssuer(issuer),
+	}
+
+	if issuer != "" {
+		opts = append(opts, WithTLSCertIssuer(issuer))
 	}
 
 	ingress, err := newIngress(gs, opts...)


### PR DESCRIPTION
Reported by https://github.com/Octops/gameserver-ingress-controller/issues/56

This fix the logic involving the Secret Name and the Terminate TLS annotation.

The option WithTLS already handles the logic and does not need to be updated. The conflict happens when the controller tries to annotate the ingress with the CertIssuer annotation.

The fix makes the WithTLSCertIssuer option only part of the reconcile if the annotation is present.