### PR TITLE
Expose max-concurrent-reconciles flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ OCTOPS_BIN := bin/octops-controller
 
 IMAGE_REPO=octops/gameserver-ingress-controller
 DOCKER_IMAGE_TAG ?= octops/gameserver-ingress-controller:${VERSION}
-RELEASE_TAG=0.2.7
+RELEASE_TAG=0.2.8
 
 default: clean build
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,23 +18,26 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/Octops/gameserver-ingress-controller/internal/runtime"
-	"github.com/Octops/gameserver-ingress-controller/pkg/app"
+	"os"
+
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
+
+	"github.com/Octops/gameserver-ingress-controller/internal/runtime"
+	"github.com/Octops/gameserver-ingress-controller/pkg/app"
 )
 
 var (
-	cfgFile                string
-	masterURL              string
-	kubeconfig             string
-	syncPeriod             string
-	webhookPort            int
-	healthProbeBindAddress string
-	metricsBindAddress     string
-	verbose                bool
+	cfgFile                 string
+	masterURL               string
+	kubeconfig              string
+	syncPeriod              string
+	webhookPort             int
+	healthProbeBindAddress  string
+	metricsBindAddress      string
+	verbose                 bool
+	maxConcurrentReconciles int
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -49,12 +52,13 @@ makes the traffic to be routed to the game server using an Ingress Controller.`,
 
 		logger := runtime.NewLogger(verbose)
 		app.StartController(ctx, logger, app.Config{
-			Kubeconfig:             kubeconfig,
-			SyncPeriod:             syncPeriod,
-			Port:                   webhookPort,
-			HealthProbeBindAddress: healthProbeBindAddress,
-			MetricsBindAddress:     metricsBindAddress,
-			Verbose:                verbose,
+			Kubeconfig:              kubeconfig,
+			SyncPeriod:              syncPeriod,
+			Port:                    webhookPort,
+			HealthProbeBindAddress:  healthProbeBindAddress,
+			MetricsBindAddress:      metricsBindAddress,
+			Verbose:                 verbose,
+			MaxConcurrentReconciles: maxConcurrentReconciles,
 		})
 	},
 }
@@ -79,6 +83,7 @@ func init() {
 	rootCmd.Flags().StringVar(&healthProbeBindAddress, "health-probe-addrs", ":30235", "TCP address that the controller should bind to for serving health probes")
 	rootCmd.Flags().StringVar(&metricsBindAddress, "metrics-addrs", ":9090", "TCP address that the controller should bind to for serving prometheus metrics")
 	rootCmd.Flags().IntVar(&webhookPort, "webhook-port", 30234, "Port used by the controller for webhooks")
+	rootCmd.Flags().IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 10, "Maximum number of concurrent reconciles which can be run simultaneously")
 	rootCmd.Flags().BoolVar(&verbose, "verbose", false, "Produce verbose log")
 }
 

--- a/deploy/install.yaml
+++ b/deploy/install.yaml
@@ -69,7 +69,7 @@ spec:
     spec:
       serviceAccountName: octops-ingress-controller
       containers:
-        - image: octops/gameserver-ingress-controller:0.2.7 # Latest release
+        - image: octops/gameserver-ingress-controller:0.2.8 # Latest release
           name: controller
           ports:
             - containerPort: 30235

--- a/pkg/app/controller.go
+++ b/pkg/app/controller.go
@@ -1,27 +1,30 @@
 package app
 
 import (
-	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
 	"context"
 	"fmt"
+	"time"
+
+	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
 	"github.com/Octops/gameserver-ingress-controller/pkg/controller"
 	"github.com/Octops/gameserver-ingress-controller/pkg/handlers"
 	"github.com/Octops/gameserver-ingress-controller/pkg/k8sutil"
 	"github.com/Octops/gameserver-ingress-controller/pkg/manager"
 	"github.com/Octops/gameserver-ingress-controller/pkg/record"
 	"github.com/Octops/gameserver-ingress-controller/pkg/stores"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"time"
 )
 
 type Config struct {
-	Kubeconfig             string
-	SyncPeriod             string
-	Port                   int
-	Verbose                bool
-	HealthProbeBindAddress string
-	MetricsBindAddress     string
+	Kubeconfig              string
+	SyncPeriod              string
+	Port                    int
+	Verbose                 bool
+	HealthProbeBindAddress  string
+	MetricsBindAddress      string
+	MaxConcurrentReconciles int
 }
 
 func StartController(ctx context.Context, logger *logrus.Entry, config Config) error {
@@ -31,10 +34,11 @@ func StartController(ctx context.Context, logger *logrus.Entry, config Config) e
 	}
 
 	mgr, err := manager.NewManager(config.Kubeconfig, manager.Options{
-		SyncPeriod:             &duration,
-		Port:                   config.Port,
-		HealthProbeBindAddress: config.HealthProbeBindAddress,
-		MetricsBindAddress:     config.MetricsBindAddress,
+		SyncPeriod:              &duration,
+		Port:                    config.Port,
+		HealthProbeBindAddress:  config.HealthProbeBindAddress,
+		MetricsBindAddress:      config.MetricsBindAddress,
+		MaxConcurrentReconciles: config.MaxConcurrentReconciles,
 	})
 	if err != nil {
 		withFatal(logger, err, "failed to create controller manager")


### PR DESCRIPTION
This PR adds the ability to configure the max concurrent reconcilers.

That is particularly important when running large scale infrastructure or with a high spike in number of game servers replicas.