### PR TITLE
Add --enable-gateway-api flag (auto/true/false) to fix startup crash without Gateway API CRDs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,7 +249,100 @@ make docker                        # build image from current source
 make run                           # docker run mounting .infrastructure/config.yml as kubeconfig
 ```
 
+Alternatively, build and run the binary directly (faster iteration, no Docker needed):
+
+```bash
+go build -o /tmp/octops-controller .
+/tmp/octops-controller --kubeconfig ~/.kube/config [flags]
+```
+
 `hack/setup-infra.sh` installs all cluster dependencies (Agones, cert-manager, both Contour variants, Gateway API CRDs, GatewayClass, and a test Gateway) from scratch. `hack/teardown-infra.sh` cleans everything up, including force-finalizing any stuck namespaces. Both scripts require `kubectl`, `helm`, and `jq`.
+
+---
+
+## Testing the `--enable-gateway-api` Flag
+
+After any change to the Gateway API CRD detection or startup logic, run these four manual checks against a live cluster. The cluster is always available via `~/.kube/config`.
+
+### Setup: Check HTTPRoute CRD presence
+
+```bash
+kubectl api-resources --api-group=gateway.networking.k8s.io | grep httproute
+```
+
+If `httproutes` is absent, tests 1–3 below are runnable. If present, skip to test 4 (or delete the CRD first with `kubectl delete crd httproutes.gateway.networking.k8s.io`).
+
+### Test 1 — `auto` mode, HTTPRoute CRD **absent** → should warn and start
+
+```bash
+/tmp/octops-controller --kubeconfig ~/.kube/config --enable-gateway-api=auto &
+sleep 5; kill %1
+```
+
+Expected output contains:
+```
+level=warning msg="Gateway API CRDs not found — gateway backend disabled..."
+```
+No `fatal` or error exit.
+
+### Test 2 — `true` mode, HTTPRoute CRD **absent** → should fail hard immediately
+
+```bash
+/tmp/octops-controller --kubeconfig ~/.kube/config --enable-gateway-api=true
+```
+
+Expected output contains:
+```
+level=fatal msg="failed to resolve --enable-gateway-api: Gateway API CRDs not found...httproutes not found in gateway.networking.k8s.io/v1"
+```
+Process must exit non-zero immediately (no delayed crash).
+
+### Test 3 — `false` mode → should always disable cleanly
+
+```bash
+/tmp/octops-controller --kubeconfig ~/.kube/config --enable-gateway-api=false &
+sleep 5; kill %1
+```
+
+Expected output contains:
+```
+level=info msg="Gateway API backend disabled (--enable-gateway-api=false)"
+```
+No errors, no CRD probe attempted.
+
+### Test 4 — `auto` mode, HTTPRoute CRD **present** → should detect and enable
+
+Install the CRD if needed (standard-install includes httproutes; experimental-install for v1.5.1 does **not** include it despite the name):
+
+```bash
+kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml"
+kubectl wait --for=condition=established crd httproutes.gateway.networking.k8s.io --timeout=30s
+```
+
+Then:
+
+```bash
+/tmp/octops-controller --kubeconfig ~/.kube/config --enable-gateway-api=auto &
+sleep 5; kill %1
+```
+
+Expected output contains:
+```
+level=info msg="Gateway API CRDs detected — gateway backend enabled (--enable-gateway-api=auto)"
+```
+
+### Important: experimental-install vs standard-install
+
+The `experimental-install.yaml` for Gateway API v1.5.1 does **not** include the `httproutes` CRD. Use `standard-install.yaml` to install HTTPRoute. The experimental bundle adds TCPRoute/UDPRoute/etc. which are needed by Contour but are separate from HTTPRoute.
+
+### Unit tests
+
+```bash
+go test ./...           # run all unit tests
+make test               # same, with cache cleared
+```
+
+Unit tests are table-driven, use no mocking frameworks, and test real object construction. They do not require a cluster.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ OCTOPS_BIN := bin/octops-controller
 
 IMAGE_REPO=octops/gameserver-ingress-controller
 DOCKER_IMAGE_TAG ?= octops/gameserver-ingress-controller:${VERSION}
-RELEASE_TAG=0.4.0
+RELEASE_TAG=0.5.0
 
 default: clean build
 

--- a/README.md
+++ b/README.md
@@ -452,6 +452,31 @@ Check logs:
 $ kubectl -n octops-system logs -f $(kubectl -n octops-system get pod -l app=octops-ingress-controller -o=jsonpath='{.items[*].metadata.name}')
 ```
 
+## Controller Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--kubeconfig` | `` | Path to kubeconfig file. Not required when running in-cluster. |
+| `--sync-period` | `15s` | Minimum frequency at which watched resources are reconciled. |
+| `--webhook-port` | `30234` | Port used for webhooks. |
+| `--health-probe-addrs` | `:30235` | Address for liveness/readiness probes (`/healthz`). |
+| `--metrics-addrs` | `:9090` | Address for Prometheus metrics. |
+| `--max-concurrent-reconciles` | `10` | Maximum number of concurrent reconcile loops. |
+| `--verbose` | `false` | Enable verbose logging. |
+| `--enable-gateway-api` | `auto` | Controls the Gateway API backend — see below. |
+
+### `--enable-gateway-api`
+
+This flag controls whether the controller creates a Gateway API (`HTTPRoute`) informer at startup. It accepts three values:
+
+| Value | Behaviour |
+|---|---|
+| `auto` (default) | Probe the cluster at startup. If `httproutes.gateway.networking.k8s.io` CRD is present, enable the Gateway API backend. If absent, log a warning and disable it — the controller starts normally and the Ingress backend continues to work. |
+| `true` | Always enable. Fail hard at startup if the HTTPRoute CRD is not installed. Use this to make a missing CRD a deployment error rather than a silent degradation. |
+| `false` | Always disable. No informer or client for Gateway API is created. Use this to keep the controller lightweight in clusters that will never use the gateway backend. |
+
+The default `auto` mode is safe for clusters that have not installed Gateway API CRDs — the controller will start and continue to manage Ingress resources normally. If a game server uses `octops.io/router-backend: gateway` while the backend is disabled, the controller will log a clear error for that specific game server rather than silently falling back to Ingress.
+
 ## Events
 You can track events recorded for each GameServer running `kubectl get events [-w]` and the output will look similar to:
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,7 @@ var (
 	metricsBindAddress      string
 	verbose                 bool
 	maxConcurrentReconciles int
+	enableGatewayAPI        string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -59,6 +60,7 @@ makes the traffic to be routed to the game server using an Ingress Controller.`,
 			MetricsBindAddress:      metricsBindAddress,
 			Verbose:                 verbose,
 			MaxConcurrentReconciles: maxConcurrentReconciles,
+			EnableGatewayAPI:        enableGatewayAPI,
 		})
 	},
 }
@@ -85,6 +87,10 @@ func init() {
 	rootCmd.Flags().IntVar(&webhookPort, "webhook-port", 30234, "Port used by the controller for webhooks")
 	rootCmd.Flags().IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 10, "Maximum number of concurrent reconciles which can be run simultaneously")
 	rootCmd.Flags().BoolVar(&verbose, "verbose", false, "Produce verbose log")
+	rootCmd.Flags().StringVar(&enableGatewayAPI, "enable-gateway-api", "auto", `Enable the Kubernetes Gateway API backend.
+  auto  – enable if Gateway API CRDs are present in the cluster (default)
+  true  – always enable; fail at startup if CRDs are missing
+  false – always disable; no informer or client is created`)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/deploy/install.yaml
+++ b/deploy/install.yaml
@@ -72,7 +72,7 @@ spec:
     spec:
       serviceAccountName: octops-ingress-controller
       containers:
-        - image: octops/gameserver-ingress-controller:0.4.0 # Latest release
+        - image: octops/gameserver-ingress-controller:0.5.0 # Latest release
           name: controller
           ports:
             - containerPort: 30235

--- a/pkg/app/controller.go
+++ b/pkg/app/controller.go
@@ -8,7 +8,9 @@ import (
 	agonesv1 "agones.dev/agones/pkg/apis/agones/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
 
+	"github.com/Octops/gameserver-ingress-controller/internal/runtime"
 	"github.com/Octops/gameserver-ingress-controller/pkg/controller"
 	"github.com/Octops/gameserver-ingress-controller/pkg/handlers"
 	"github.com/Octops/gameserver-ingress-controller/pkg/k8sutil"
@@ -25,6 +27,11 @@ type Config struct {
 	HealthProbeBindAddress  string
 	MetricsBindAddress      string
 	MaxConcurrentReconciles int
+	// EnableGatewayAPI controls the Gateway API backend.
+	// "auto" (default): enable if CRDs are present, warn and disable if not.
+	// "true": always enable, fail hard at startup if CRDs are missing.
+	// "false": always disable, no informer or client created.
+	EnableGatewayAPI string
 }
 
 func StartController(ctx context.Context, logger *logrus.Entry, config Config) error {
@@ -53,7 +60,13 @@ func StartController(ctx context.Context, logger *logrus.Entry, config Config) e
 	if err != nil {
 		withFatal(logger, err, "failed to create kubernetes client")
 	}
-	store, err := stores.NewStore(ctx, client, clusterConfig)
+
+	gatewayEnabled, err := resolveGatewayAPIEnabled(config.EnableGatewayAPI, client, logger)
+	if err != nil {
+		withFatal(logger, err, "failed to resolve --enable-gateway-api")
+	}
+
+	store, err := stores.NewStore(ctx, client, clusterConfig, gatewayEnabled)
 	if err != nil {
 		withFatal(logger, err, "failed to create store")
 	}
@@ -61,7 +74,7 @@ func StartController(ctx context.Context, logger *logrus.Entry, config Config) e
 	agones, err := stores.NewAgonesStore(ctx, clusterConfig, duration)
 
 	recorder := mgr.GetEventRecorderFor("octops-gameserver-controller")
-	handler := handlers.NewGameSeverEventHandler(store, agones, record.NewEventRecorder(recorder))
+	handler := handlers.NewGameSeverEventHandler(store, agones, record.NewEventRecorder(recorder), gatewayEnabled)
 
 	ctrl, err := controller.NewGameServerController(ctx, mgr, handler, controller.Options{
 		For: &agonesv1.GameServer{},
@@ -77,6 +90,52 @@ func StartController(ctx context.Context, logger *logrus.Entry, config Config) e
 	}
 
 	return nil
+}
+
+// resolveGatewayAPIEnabled determines whether the Gateway API backend should be
+// enabled based on the --enable-gateway-api flag value:
+//
+//	"false" – always disabled
+//	"true"  – always enabled; return error if CRDs are absent
+//	"auto"  – enabled if gateway.networking.k8s.io/v1 is registered, disabled otherwise
+func resolveGatewayAPIEnabled(mode string, client kubernetes.Interface, logger *logrus.Entry) (bool, error) {
+	log := runtime.Logger().WithField("component", "gateway-api")
+
+	switch mode {
+	case "false":
+		log.Info("Gateway API backend disabled (--enable-gateway-api=false)")
+		return false, nil
+	case "true":
+		if err := checkGatewayAPICRDs(client); err != nil {
+			return false, errors.Wrap(err, "Gateway API CRDs not found (--enable-gateway-api=true requires them to be installed)")
+		}
+		log.Info("Gateway API backend enabled (--enable-gateway-api=true)")
+		return true, nil
+	default: // "auto"
+		if err := checkGatewayAPICRDs(client); err != nil {
+			log.Warn("Gateway API CRDs not found — gateway backend disabled. Install CRDs or set --enable-gateway-api=true to require them.")
+			return false, nil
+		}
+		log.Info("Gateway API CRDs detected — gateway backend enabled (--enable-gateway-api=auto)")
+		return true, nil
+	}
+}
+
+// checkGatewayAPICRDs returns nil if the HTTPRoute resource is served under
+// gateway.networking.k8s.io/v1. Checking the group alone is insufficient
+// because other Gateway API CRDs (Gateway, GatewayClass) may be present while
+// HTTPRoute is absent.
+func checkGatewayAPICRDs(client kubernetes.Interface) error {
+	resources, err := client.Discovery().ServerResourcesForGroupVersion("gateway.networking.k8s.io/v1")
+	if err != nil {
+		return err
+	}
+	for _, r := range resources.APIResources {
+		if r.Name == "httproutes" {
+			return nil
+		}
+	}
+	return errors.New("httproutes not found in gateway.networking.k8s.io/v1")
 }
 
 func withFatal(logger *logrus.Entry, err error, msg string) {

--- a/pkg/handlers/gameserver_handler.go
+++ b/pkg/handlers/gameserver_handler.go
@@ -25,14 +25,17 @@ type GameSeverEventHandler struct {
 	gameserverReconciler *reconcilers.GameServerReconciler
 }
 
-func NewGameSeverEventHandler(store *stores.Store, agones *stores.AgonesStore, recorder *record.EventRecorder) *GameSeverEventHandler {
-	return &GameSeverEventHandler{
+func NewGameSeverEventHandler(store *stores.Store, agones *stores.AgonesStore, recorder *record.EventRecorder, gatewayEnabled bool) *GameSeverEventHandler {
+	h := &GameSeverEventHandler{
 		logger:               runtime.Logger().WithField("component", "event_handler"),
 		serviceReconciler:    reconcilers.NewServiceReconciler(store, recorder),
 		ingressReconciler:    reconcilers.NewIngressReconciler(store, recorder),
-		gatewayReconciler:    reconcilers.NewGatewayReconciler(store, recorder),
 		gameserverReconciler: reconcilers.NewGameServerReconciler(agones, recorder),
 	}
+	if gatewayEnabled {
+		h.gatewayReconciler = reconcilers.NewGatewayReconciler(store, recorder)
+	}
+	return h
 }
 
 func (h *GameSeverEventHandler) OnAdd(ctx context.Context, obj interface{}) error {
@@ -91,6 +94,13 @@ func (h *GameSeverEventHandler) Reconcile(ctx context.Context, logger *logrus.En
 	var routeReconciled bool
 	switch gameserver.GetRouterBackend(gs) {
 	case gameserver.RouterBackendGateway:
+		if h.gatewayReconciler == nil {
+			return errors.Errorf(
+				"gameserver %s requests router-backend=gateway but the Gateway API backend is disabled; "+
+					"restart the controller with --enable-gateway-api=true or install Gateway API CRDs",
+				k8sutil.Namespaced(gs),
+			)
+		}
 		_, routeReconciled, err = h.gatewayReconciler.Reconcile(ctx, gs)
 		if err != nil {
 			return errors.Wrapf(err, "failed to reconcile HTTPRoute %s", k8sutil.Namespaced(gs))

--- a/pkg/stores/store.go
+++ b/pkg/stores/store.go
@@ -20,26 +20,27 @@ type Store struct {
 	*gatewayStore
 }
 
-func NewStore(ctx context.Context, client kubernetes.Interface, restConfig *rest.Config) (*Store, error) {
+func NewStore(ctx context.Context, client kubernetes.Interface, restConfig *rest.Config, gatewayEnabled bool) (*Store, error) {
 	factory := informers.NewSharedInformerFactory(client, 0)
 	services := factory.Core().V1().Services()
 	ingresses := factory.Networking().V1().Ingresses()
 
-	gwClient, err := gatewayclient.NewForConfig(restConfig)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create gateway-api client")
-	}
-
-	gwFactory := gatewayinformers.NewSharedInformerFactory(gwClient, 0)
-	httpRoutes := gwFactory.Gateway().V1().HTTPRoutes()
-
 	go factory.Start(ctx.Done())
-	go gwFactory.Start(ctx.Done())
 
 	store := &Store{
-		newServiceStore(client, services),
-		newIngressStore(client, ingresses),
-		newGatewayStore(gwClient, httpRoutes),
+		serviceStore: newServiceStore(client, services),
+		ingressStore: newIngressStore(client, ingresses),
+	}
+
+	if gatewayEnabled {
+		gwClient, err := gatewayclient.NewForConfig(restConfig)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create gateway-api client")
+		}
+		gwFactory := gatewayinformers.NewSharedInformerFactory(gwClient, 0)
+		httpRoutes := gwFactory.Gateway().V1().HTTPRoutes()
+		go gwFactory.Start(ctx.Done())
+		store.gatewayStore = newGatewayStore(gwClient, httpRoutes)
 	}
 
 	if err := store.HasSynced(ctx); err != nil {
@@ -50,16 +51,20 @@ func NewStore(ctx context.Context, client kubernetes.Interface, restConfig *rest
 }
 
 func (s *Store) HasSynced(ctx context.Context) error {
-	svcInformer := s.serviceStore.informer.Informer()
-	ingInformer := s.ingressStore.informer.Informer()
-	gwInformer := s.gatewayStore.informer.Informer()
+	syncFuncs := []cache.InformerSynced{
+		s.serviceStore.informer.Informer().HasSynced,
+		s.ingressStore.informer.Informer().HasSynced,
+	}
+	if s.gatewayStore != nil {
+		syncFuncs = append(syncFuncs, s.gatewayStore.informer.Informer().HasSynced)
+	}
 
 	f := func() error {
 		stopper, cancel := context.WithTimeout(ctx, time.Second*15)
 		defer cancel()
 
 		runtime.Logger().WithField("component", "store").Info("waiting for K8S cache to sync")
-		if !cache.WaitForCacheSync(stopper.Done(), svcInformer.HasSynced, ingInformer.HasSynced, gwInformer.HasSynced) {
+		if !cache.WaitForCacheSync(stopper.Done(), syncFuncs...) {
 			return errors.New("timed out waiting for K8S cache to sync")
 		}
 		return nil


### PR DESCRIPTION
## Problem

Users not running the Gateway API backend hit a fatal startup crash because the controller unconditionally created a Gateway API informer. Without `httproutes.gateway.networking.k8s.io` CRD installed, the informer fails with:

```
failed to list *v1.HTTPRoute: the server could not find the requested resource
```

This broke all ingress-only users who upgraded to the version that added Gateway API support.

## Solution

Add a `--enable-gateway-api` flag (default: `auto`) that probes for the HTTPRoute CRD at startup and conditionally enables the gateway backend:

| Value | Behaviour |
|---|---|
| `auto` (default) | Detect at startup — enable if `httproutes` CRD is present, warn and disable if absent. Safe for all existing deployments. |
| `true` | Always enable. Fail hard at startup if CRD is missing. |
| `false` | Always disable. No informer or client created. |

The detection checks for the `httproutes` resource specifically within `gateway.networking.k8s.io/v1` — not just group presence — so other Gateway CRDs (`gateways`, `gatewayclasses`) being present without `httproutes` is correctly handled.

A nil-guard in `GameSeverEventHandler.Reconcile` returns a clear, actionable per-GameServer error if a fleet uses `router-backend=gateway` while the backend is disabled, rather than panicking.

## Changes

- `pkg/app/controller.go` — `resolveGatewayAPIEnabled` + `checkGatewayAPICRDs`; `Config.EnableGatewayAPI` field
- `pkg/stores/store.go` — `NewStore` accepts `gatewayEnabled bool`; gateway client/informer created conditionally
- `pkg/handlers/gameserver_handler.go` — `NewGameSeverEventHandler` accepts `gatewayEnabled bool`; nil-guard with actionable error
- `cmd/root.go` — `--enable-gateway-api` flag wired in
- `deploy/install.yaml` — image tag bumped to `0.5.0`
- `Makefile` — `RELEASE_TAG` bumped to `0.5.0`
- `README.md` — Controller Flags section with `--enable-gateway-api` documented
- `AGENTS.md` — Manual test procedure for all four scenarios

## Test plan

- [ ] `--enable-gateway-api=auto` with HTTPRoute CRD absent → warning logged, controller starts, ingress backend works
- [ ] `--enable-gateway-api=true` with HTTPRoute CRD absent → fatal at startup with clear error
- [ ] `--enable-gateway-api=false` → disabled log line, controller starts cleanly
- [ ] `--enable-gateway-api=auto` with HTTPRoute CRD present → detected and enabled
- [ ] `go test ./...` passes

All four scenarios were validated against the dev cluster before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)